### PR TITLE
Make serialization optional in gp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ openblas-system = ["linfa/openblas-system"]
 intel-mkl-static = ["linfa/intel-mkl-static"]
 intel-mkl-system = ["linfa/intel-mkl-system"]
 
-serde = ["linfa/serde"]
+serializable = ["linfa/serde", "egobox-gp/serializable"]
 
 [dependencies]
 egobox-doe = { version = "0.2.1", path="./doe" }

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Rust toolbox for Efficient Global Optimization algorithms inspired from [SMT](ht
 
 | Name         | Version                                                                                         | Documentation                                                               | Description                                                                     |
 | :----------- | :---------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| [doe](./doe) | [![crates.io](https://img.shields.io/crates/v/egobox-doe)](https://crates.io/crates/egobox-doe) | [![docs](https://docs.rs/egobox-doe/badge.svg)](https://docs.rs/egobox-doe) | sampling methods; contains LHS, FullFactorial, Random methods          |
-| [gp](./gp)   | [![crates.io](https://img.shields.io/crates/v/egobox-gp)](https://crates.io/crates/egobox-gp)   | [![docs](https://docs.rs/egobox-gp/badge.svg)](https://docs.rs/egobox-gp)   | gaussian process regression; contains Kriging and PLS dimension reduction      |
+| [doe](./doe) | [![crates.io](https://img.shields.io/crates/v/egobox-doe)](https://crates.io/crates/egobox-doe) | [![docs](https://docs.rs/egobox-doe/badge.svg)](https://docs.rs/egobox-doe) | sampling methods; contains LHS, FullFactorial, Random methods                   |
+| [gp](./gp)   | [![crates.io](https://img.shields.io/crates/v/egobox-gp)](https://crates.io/crates/egobox-gp)   | [![docs](https://docs.rs/egobox-gp/badge.svg)](https://docs.rs/egobox-gp)   | gaussian process regression; contains Kriging and PLS dimension reduction       |
 | [moe](./gp)  | [![crates.io](https://img.shields.io/crates/v/egobox-moe)](https://crates.io/crates/egobox-moe) | [![docs](https://docs.rs/egobox-moe/badge.svg)](https://docs.rs/egobox-moe) | mixture of experts using GP models                                              |
 | [ego](./ego) | [![crates.io](https://img.shields.io/crates/v/egobox-ego)](https://crates.io/crates/egobox-ego) | [![docs](https://docs.rs/egobox-ego/badge.svg)](https://docs.rs/egobox-ego) | efficient global optimization with basic constraints and mixed integer handling |
 
@@ -30,7 +30,22 @@ egobox-ego = { version = "0.2.1" }
 
 ## Features
 
-`gp`, `moe` and `ego` relies on `linfa` [BLAS/Lapack backend features](https://github.com/rust-ml/linfa#blaslapack-backend).
+### linfa BLAS/Lapack backend feature
+
+ relies on `linfa` [BLAS/Lapack backend features](https://github.com/rust-ml/linfa#blaslapack-backend).
+
+End user project using `gp`, `moe` and `ego` should select a BLAS/Lapack backend 
+depending its environment; it can be either: 
+ * Openblas: `linfa\openblas-system` or `linfa\openblas-static`
+ * Netlib: `linfa\netlib-system` or `linfa\netlib-static`
+ * Intel MKL: `linfa\intel-mkl-system` or `linfa\intel-mkl-static`
+
+where
+
+ * `*-system` features: try to find the corresponding backend in your installation.
+ * `*-static` features: try to download and compile the corresponing backend.
+
+More information in [linfa features](https://github.com/rust-ml/linfa#blaslapack-backend)
 
 For instance, using `gp` with the Intel MKL BLAS/Lapack backend, you have to specify the linfa backend feature :
 
@@ -40,6 +55,10 @@ egobox-gp = { version = "0.2.1", features = ["linfa/intel-mkl-static"] }
 ```
 
 Note: only end-user projects should specify a provider in `Cargo.toml` (not librairies). In case of library development, the backend is specified on the command line as for examples below.
+
+### `serializable` 
+
+The `serializable` feature of enables the serialization of GP models using the [serde crate](https://serde.rs/). 
 
 ## Examples
 

--- a/gp/Cargo.toml
+++ b/gp/Cargo.toml
@@ -12,13 +12,15 @@ categories = ["algorithms", "mathematics", "science"]
 [features]
 default = []
 
+serializable = ["linfa/serde", "serde"]
+
 [dependencies]
 egobox-doe = { version = "0.2.1", path="../doe" }
 
 linfa = { version = "0.5.1", default-features = false }
 linfa-pls = { version = "0.5.1", default-features = false }
 
-ndarray = { version = "0.15", features = ["rayon", "approx", "serde"]}
+ndarray = { version = "0.15", features = ["rayon", "approx"]}
 ndarray-linalg = "0.14"
 ndarray-stats = "0.5"
 ndarray_einsum_beta = "0.7"
@@ -29,8 +31,14 @@ cobyla = "0.1.2"
 rand_isaac = "0.3"
 paste = "1.0"
 num-traits = "0.2"
-serde = {version = "1", features = ["derive"]}
 thiserror = "1"
+
+[dependencies.serde]
+package = "serde"
+version = "1.0"
+default-features = false
+features = ["std", "derive"]
+optional = true
 
 [dev-dependencies]
 criterion = "0.3"

--- a/gp/src/correlation_models.rs
+++ b/gp/src/correlation_models.rs
@@ -7,6 +7,7 @@
 
 use linfa::Float;
 use ndarray::{Array2, ArrayBase, Axis, Data, Ix1, Ix2};
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -22,10 +23,13 @@ pub trait CorrelationModel<F: Float>: Clone + Copy + Default {
     ) -> Array2<F>;
 }
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
-
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 /// Squared exponential correlation models
 pub struct SquaredExponentialCorr();
 
@@ -60,9 +64,13 @@ impl<F: Float> CorrelationModel<F> for SquaredExponentialCorr {
     }
 }
 /// Absolute exponential correlation models
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct AbsoluteExponentialCorr();
 
 impl From<AbsoluteExponentialCorr> for String {
@@ -97,9 +105,13 @@ impl<F: Float> CorrelationModel<F> for AbsoluteExponentialCorr {
 }
 
 /// Matern 3/2 correlation model
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct Matern32Corr();
 
 impl From<Matern32Corr> for String {
@@ -140,9 +152,13 @@ impl<F: Float> CorrelationModel<F> for Matern32Corr {
 }
 
 /// Matern 5/2 correlation model
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct Matern52Corr();
 
 impl From<Matern52Corr> for String {

--- a/gp/src/lib.rs
+++ b/gp/src/lib.rs
@@ -12,8 +12,8 @@
 //! `Y(x) = mu(x) + Z(x)`
 //!
 //! where:
-//! * `mu(x)` is the trend acting as the mean of the process
-//! * `Z(x)` the realization of stochastic Gaussian process ~ `Normal(0, sigma^2)`
+//! * `mu(x)` is the trend i.e. the mean of the gaussian process
+//! * `Z(x)` the realization of stochastic gaussian process ~ `Normal(0, sigma^2)`
 //!
 //! which in turn is written as:
 //!
@@ -26,8 +26,9 @@
 //! * `corr(x, x')` is a correlation function which depends on `distance(x, x')`
 //! and a set of unknown parameters `thetas` to be determined.
 //!
-//! Implementation highlights:
-//! * This library is based on [ndarray](https://github.com/rust-ndarray/ndarray)
+//! # Highlights
+//!
+//! * Based on [ndarray](https://github.com/rust-ndarray/ndarray)
 //! and [linfa](https://github.com/rust-ml/linfa) and strive to follow [linfa guidelines](https://github.com/rust-ml/linfa/blob/master/CONTRIBUTE.md)
 //! * GP mean model can be constant, linear or quadratic
 //! * GP correlation model can be build the following kernels: squared exponential, absolute exponential, matern 3/2, matern 5/2    
@@ -37,6 +38,29 @@
 //! To work around this problem the library implements dimension reduction using
 //! Partial Least Squares method upon Kriging method also known as KPLS algorithm (see Reference)
 //! * GP models can be saved and loaded using [serde](https://serde.rs/).
+//! See `serializable` feature section below.
+//!
+//! # Features
+//!
+//! ## linfa features
+//!
+//! End-user project should select a BLAS/Lapack backend depending its environment;
+//! it can be either:
+//!
+//! * Openblas: `linfa\openblas-system` or `linfa\openblas-static`
+//! * Netlib: `linfa\netlib-system` or `linfa\netlib-static`
+//! * Intel MKL: `linfa\intel-mkl-system` or `linfa\intel-mkl-static`
+//!
+//! where
+//!
+//! * `*-system` features: try to find the corresponding backend in your installation.
+//! * `*-static` features: try to download and compile the corresponing backend.
+//!
+//! More information in [linfa features](https://github.com/rust-ml/linfa#blaslapack-backend)
+//!
+//! ## serializable
+//!
+//! The `serializable` feature enables the serialization using the [serde crate](https://serde.rs/).
 //!
 //! # Example
 //!

--- a/gp/src/mean_models.rs
+++ b/gp/src/mean_models.rs
@@ -1,12 +1,12 @@
 //! A module for regression models used by GP models.
-//! The following kernels are implemented:
-//! * squared exponential,
-//! * absolute exponential,
-//! * matern 3/2,
-//! * matern 5/2.
+//! The following models are implemented:
+//! * constant,
+//! * linear,
+//! * quadratic
 
 use linfa::Float;
 use ndarray::{concatenate, s, Array2, ArrayBase, Axis, Data, Ix2};
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -17,9 +17,13 @@ pub trait RegressionModel<F: Float>: Clone + Copy + Default {
 }
 
 /// A constant function as mean of the GP
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct ConstantMean();
 
 impl<F: Float> RegressionModel<F> for ConstantMean {
@@ -46,9 +50,13 @@ impl TryFrom<String> for ConstantMean {
 }
 
 /// An affine function as mean of the GP
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct LinearMean();
 
 impl<F: Float> RegressionModel<F> for LinearMean {
@@ -76,9 +84,13 @@ impl TryFrom<String> for LinearMean {
 }
 
 /// A 2-degree polynomial as mean of the GP
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
-#[serde(into = "String")]
-#[serde(try_from = "String")]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(
+    feature = "serializable",
+    derive(Serialize, Deserialize),
+    serde(into = "String"),
+    serde(try_from = "String")
+)]
 pub struct QuadraticMean();
 
 impl<F: Float> RegressionModel<F> for QuadraticMean {

--- a/gp/src/utils.rs
+++ b/gp/src/utils.rs
@@ -1,10 +1,12 @@
 use linfa::Float;
 use ndarray::{s, Array1, Array2, ArrayBase, Axis, Data, Ix2};
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 
 /// A structure to store data and its mean and standard deviation vectors
 /// Data is a (n, xdim) matrix
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct NormalizedMatrix<F: Float> {
     /// data
     pub data: Array2<F>,

--- a/moe/Cargo.toml
+++ b/moe/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
 egobox-doe = { version = "0.2.1", path = "../doe" }
-egobox-gp = { version = "0.2.1", path = "../gp" }
+egobox-gp = { version = "0.2.1", path = "../gp", features = ["serializable"] }
 
 linfa = { version = "0.5.1", default-features = false }
 linfa-clustering = { version = "0.5.1", default-features = false }


### PR DESCRIPTION
Now using gp, if serialization (`serde`) is required the feature `serializable` has to be enabled

- [x] Add feature `serializable` and manage `serde` dependency as optional
- [x] Update documentation