### PR TITLE
Refactor ego/moe relation

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -175,10 +175,10 @@ pub struct Egor<'a, O: GroupFunc, R: Rng> {
     /// functions, otherwise [mixture of expert](egobox_moe) is used
     /// Note: if specified takes precedence over individual settings
     pub surrogate_builder: Option<&'a dyn SurrogateBuilder>,
-    /// An optional evaluator used to run the function under optimization
-    /// allowing to adjust pre or post processing around function evaluation,
-    /// the function is run directly otherwise
-    pub evaluator: Option<&'a dyn Evaluator>,
+    /// An optional pre-processor used to preprocess continuous input given
+    /// to the function under optimization, specially with mixed integer
+    /// function optimization
+    pub pre_proc: Option<&'a dyn PreProcessor>,
     /// The function under optimization f(x) = [objective, cstr1, ..., cstrn], (n_cstr+1 size)
     pub obj: O,
     /// A random generator used to get reproductible results.
@@ -218,7 +218,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             outdir: None,
             hot_start: false,
             surrogate_builder: None,
-            evaluator: None,
+            pre_proc: None,
             obj: f,
             rng,
         }
@@ -317,8 +317,8 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
         self
     }
 
-    pub fn evaluator(&mut self, evaluator: Option<&'a dyn Evaluator>) -> &mut Self {
-        self.evaluator = evaluator;
+    pub fn pre_proc(&mut self, pre_proc: Option<&'a dyn PreProcessor>) -> &mut Self {
+        self.pre_proc = pre_proc;
         self
     }
 
@@ -343,7 +343,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             outdir: self.outdir,
             hot_start: self.hot_start,
             surrogate_builder: self.surrogate_builder,
-            evaluator: self.evaluator,
+            pre_proc: self.pre_proc,
             obj: self.obj,
             rng,
         }
@@ -425,6 +425,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
         let mut no_point_added_retries = MAX_RETRY;
         for i in 1..=n_iter {
             let (x_dat, y_dat) = self.next_points(i, &x_data, &y_data, &sampling);
+            debug!("Try adding {}", x_dat);
             let rejected_count = update_data(&mut x_data, &mut y_data, &x_dat, &y_dat);
             if rejected_count > 0 {
                 info!(
@@ -482,11 +483,13 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             }
         }
         let best_index = self.find_best_result_index(&y_data);
-        info!("{}", concatenate![Axis(1), x_data, y_data]);
-        Ok(OptimResult {
+        info!("History: \n{}", concatenate![Axis(1), x_data, y_data]);
+        let res = OptimResult {
             x_opt: x_data.row(best_index).to_owned(),
             y_opt: y_data.row(best_index).to_owned(),
-        })
+        };
+        info!("Optim Result: min f(x)={} at x= {}", res.y_opt, res.x_opt);
+        Ok(res)
     }
 
     fn next_points(
@@ -496,6 +499,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
         y_data: &Array2<f64>,
         sampling: &Lhs<f64, R>,
     ) -> (Array2<f64>, Array2<f64>) {
+        debug!("Make surrogate with {}", x_data);
         let mut x_dat = Array2::zeros((0, x_data.ncols()));
         let mut y_dat = Array2::zeros((0, y_data.ncols()));
         let n_clusters = self.n_clusters.unwrap_or(1);
@@ -746,10 +750,10 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
     }
 }
 
-impl<'a, O: GroupFunc, R: Rng + Clone> Evaluator for Egor<'a, O, R> {
+impl<'a, O: GroupFunc, R: Rng + Clone> PreProcessor for Egor<'a, O, R> {
     fn eval(&self, x: &Array2<f64>) -> Array2<f64> {
-        if let Some(evaluator) = self.evaluator {
-            (self.obj)(&evaluator.eval(x).view())
+        if let Some(pre_proc) = self.pre_proc {
+            (self.obj)(&pre_proc.eval(x).view())
         } else {
             (self.obj)(&x.view())
         }

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -97,9 +97,10 @@ use crate::utils::update_data;
 use crate::utils::{compute_cstr_scales, compute_obj_scale, compute_wb2s_scale};
 use crate::utils::{ei, wb2s};
 use egobox_doe::{Lhs, LhsKind, SamplingMethod};
-use egobox_moe::{CorrelationSpec, Moe, MoeFit, RegressionSpec, Surrogate};
+use egobox_moe::{CorrelationSpec, Moe, MoeParams, RegressionSpec, Surrogate};
 use env_logger::{Builder, Env};
 use finitediff::FiniteDiff;
+use linfa::{traits::Fit, Dataset, ParamGuard};
 use log::{debug, info};
 use ndarray::{concatenate, s, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2, Zip};
 use ndarray_linalg::Scalar;
@@ -112,22 +113,19 @@ use rand_isaac::Isaac64Rng;
 const DOE_INITIAL_FILE: &str = "egor_initial_doe.npy";
 const DOE_FILE: &str = "egobox_doe.npy";
 
-#[derive(Clone, Copy, Debug)]
-pub struct ApproxValue {
-    pub value: f64,
-    pub tolerance: f64,
-}
-
 /// Data used by internal infill criteria to be optimized using NlOpt
-pub struct ObjData<F> {
+struct ObjData<F> {
     pub scale_obj: F,
     pub scale_cstr: Array1<F>,
     pub scale_wb2: F,
 }
 
-/// An interface for "function under optimization" evaluation
-pub trait Evaluator {
-    fn eval(&self, x: &Array2<f64>) -> Array2<f64>;
+impl<R: Rng + SeedableRng + Clone> SurrogateBuilder for MoeParams<f64, R> {
+    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn Surrogate>> {
+        let checked = self.check_ref()?;
+        let moe = checked.fit(&Dataset::new(xt.to_owned(), yt.to_owned()))?;
+        Ok(moe).map(|moe| Box::new(moe) as Box<dyn Surrogate>)
+    }
 }
 
 /// EGO optimization parameterization
@@ -173,10 +171,13 @@ pub struct Egor<'a, O: GroupFunc, R: Rng> {
     pub outdir: Option<String>,
     /// If true use <outdir> to retrieve and start from previous results
     pub hot_start: bool,
-    /// MoE parameters (see [egobox_moe])
+    /// An optional surrogate builder used to model objective and constraint
+    /// functions, otherwise [mixture of expert](egobox_moe) is used
     /// Note: if specified takes precedence over individual settings
-    pub moe_params: Option<&'a dyn MoeFit>,
-    /// An evaluator used to run the function under optimization
+    pub surrogate_builder: Option<&'a dyn SurrogateBuilder>,
+    /// An optional evaluator used to run the function under optimization
+    /// allowing to adjust pre or post processing around function evaluation,
+    /// the function is run directly otherwise
     pub evaluator: Option<&'a dyn Evaluator>,
     /// The function under optimization f(x) = [objective, cstr1, ..., cstrn], (n_cstr+1 size)
     pub obj: O,
@@ -216,7 +217,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             expected: None,
             outdir: None,
             hot_start: false,
-            moe_params: None,
+            surrogate_builder: None,
             evaluator: None,
             obj: f,
             rng,
@@ -308,8 +309,11 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
         self
     }
 
-    pub fn moe_params(&mut self, moe_params: Option<&'a dyn MoeFit>) -> &mut Self {
-        self.moe_params = moe_params;
+    pub fn surrogate_builder(
+        &mut self,
+        surrogate_builder: Option<&'a dyn SurrogateBuilder>,
+    ) -> &mut Self {
+        self.surrogate_builder = surrogate_builder;
         self
     }
 
@@ -338,7 +342,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             expected: self.expected,
             outdir: self.outdir,
             hot_start: self.hot_start,
-            moe_params: self.moe_params,
+            surrogate_builder: self.surrogate_builder,
             evaluator: self.evaluator,
             obj: self.obj,
             rng,
@@ -496,20 +500,21 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
         let mut y_dat = Array2::zeros((0, y_data.ncols()));
         let n_clusters = self.n_clusters.unwrap_or(1);
 
-        let default_params = &Moe::params(n_clusters)
+        let default_builder = &Moe::params(n_clusters)
             .kpls_dim(self.kpls_dim)
             .regression_spec(self.regression_spec)
-            .correlation_spec(self.correlation_spec) as &dyn MoeFit;
-        let params = self.moe_params.unwrap_or(default_params);
+            .correlation_spec(self.correlation_spec)
+            as &dyn SurrogateBuilder;
+        let builder = self.surrogate_builder.unwrap_or(default_builder);
 
-        let obj_model = params
-            .train(x_data, &y_data.slice(s![.., 0_usize..1]).to_owned())
+        let obj_model = builder
+            .train(x_data, &y_data.slice(s![.., 0..1]).to_owned())
             .expect("GP training failure");
 
         let mut cstr_models: Vec<Box<dyn Surrogate>> = Vec::with_capacity(self.n_cstr);
         for k in 0..self.n_cstr {
             cstr_models.push(
-                params
+                builder
                     .train(x_data, &y_data.slice(s![.., k + 1..k + 2]).to_owned())
                     .expect("GP training failure"),
             )

--- a/ego/src/lib.rs
+++ b/ego/src/lib.rs
@@ -42,7 +42,9 @@
 //!  
 //! ```no_run   
 //! use ndarray::{array, Array2, ArrayView2};
-//! use egobox_ego::MixintEgor;
+//! use ndarray_linalg::Norm;
+//! use egobox_moe::MoeParams;
+//! use egobox_ego::{MixintEgor,  MixintMoeParams, MixintPreProcessor, InfillStrategy, Xtype};
 //!
 //! fn mixsinx(x: &ArrayView2<f64>) -> Array2<f64> {
 //!     if (x.mapv(|v| v.round()).norm_l2() - x.norm_l2()).abs() < 1e-6 {

--- a/ego/src/mixintegor.rs
+++ b/ego/src/mixintegor.rs
@@ -35,7 +35,7 @@ impl<'a, O: GroupFunc, R: Rng + Clone> MixintEgor<'a, O, R> {
     ) -> Self {
         let xlimits = unfold_xlimits_with_continuous_limits(mix_params.xtypes());
         let egor = Egor::new_with_rng(f, &xlimits, rng)
-            .moe_params(Some(mix_params))
+            .surrogate_builder(Some(mix_params))
             .evaluator(Some(evaluator))
             .clone();
         MixintEgor {
@@ -102,10 +102,10 @@ mod tests {
         let doe = array![[0.], [7.], [25.]];
         let xtypes = vec![Xtype::Int(0, 25)];
 
-        let moe_params = MoeParams::default();
-        let moe_params = MixintMoeParams::new(&xtypes, &moe_params);
+        let surrogate_builder = MoeParams::default();
+        let surrogate_builder = MixintMoeParams::new(&xtypes, &surrogate_builder);
         let evaluator = MixintEvaluator::new(&xtypes);
-        let mut mixintegor = MixintEgor::new(mixsinx, &moe_params, &evaluator);
+        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &evaluator);
         mixintegor
             .egor
             .doe(Some(doe))
@@ -125,10 +125,10 @@ mod tests {
         let n_eval = 10;
         let xtypes = vec![Xtype::Int(0, 25)];
 
-        let moe_params = MoeParams::default();
-        let moe_params = MixintMoeParams::new(&xtypes, &moe_params);
+        let surrogate_builder = MoeParams::default();
+        let surrogate_builder = MixintMoeParams::new(&xtypes, &surrogate_builder);
         let evaluator = MixintEvaluator::new(&xtypes);
-        let mut mixintegor = MixintEgor::new(mixsinx, &moe_params, &evaluator);
+        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &evaluator);
         mixintegor
             .egor
             .n_eval(n_eval)

--- a/ego/src/mixintegor.rs
+++ b/ego/src/mixintegor.rs
@@ -20,9 +20,9 @@ impl<'a, O: GroupFunc> MixintEgor<'a, O, Isaac64Rng> {
     pub fn new(
         f: O,
         mix_params: &'a MixintMoeParams,
-        evaluator: &'a MixintEvaluator,
+        pre_proc: &'a MixintPreProcessor,
     ) -> MixintEgor<'a, O, Isaac64Rng> {
-        Self::new_with_rng(f, mix_params, evaluator, Isaac64Rng::from_entropy())
+        Self::new_with_rng(f, mix_params, pre_proc, Isaac64Rng::from_entropy())
     }
 }
 
@@ -30,13 +30,13 @@ impl<'a, O: GroupFunc, R: Rng + Clone> MixintEgor<'a, O, R> {
     pub fn new_with_rng(
         f: O,
         mix_params: &'a MixintMoeParams,
-        evaluator: &'a MixintEvaluator,
+        pre_proc: &'a MixintPreProcessor,
         rng: R,
     ) -> Self {
         let xlimits = unfold_xlimits_with_continuous_limits(mix_params.xtypes());
         let egor = Egor::new_with_rng(f, &xlimits, rng)
             .surrogate_builder(Some(mix_params))
-            .evaluator(Some(evaluator))
+            .pre_proc(Some(pre_proc))
             .clone();
         MixintEgor {
             xtypes: mix_params.xtypes().to_vec(),
@@ -51,30 +51,36 @@ impl<'a, O: GroupFunc, R: Rng + Clone> MixintEgor<'a, O, R> {
             let x_opt = opt.x_opt.to_owned().insert_axis(Axis(0));
             let x_opt = get_cast_to_discrete_values(&self.xtypes, &x_opt);
             let x_opt = fold_with_enum_index(&self.xtypes, &x_opt.view());
-            OptimResult {
+            let res = OptimResult {
                 x_opt: x_opt.row(0).to_owned(),
-                y_opt: opt.y_opt.to_owned(),
-            }
+                y_opt: opt.y_opt,
+            };
+            log::info!(
+                "Mixint Optim Result: min f(x)={} at x={}  ",
+                res.y_opt,
+                res.x_opt
+            );
+            res
         })
     }
 }
 
-/// An evaluator for the function under optimization taking into account
+/// An pre_proc for the function under optimization taking into account
 /// discrete input variables specification.
-pub struct MixintEvaluator {
+pub struct MixintPreProcessor {
     xtypes: Vec<Xtype>,
 }
 
-impl Evaluator for MixintEvaluator {
+impl PreProcessor for MixintPreProcessor {
     fn eval(&self, x: &Array2<f64>) -> Array2<f64> {
         let fold = fold_with_enum_index(&self.xtypes, &x.view());
         get_cast_to_discrete_values(&self.xtypes, &fold)
     }
 }
 
-impl MixintEvaluator {
+impl MixintPreProcessor {
     pub fn new(xtypes: &[Xtype]) -> Self {
-        MixintEvaluator {
+        MixintPreProcessor {
             xtypes: xtypes.to_vec(),
         }
     }
@@ -84,9 +90,11 @@ impl MixintEvaluator {
 mod tests {
     use super::*;
     use crate::mixint::Xtype;
+    use approx::assert_abs_diff_eq;
     use egobox_moe::MoeParams;
     use ndarray::{array, Array2, ArrayView2};
     use ndarray_linalg::Norm;
+    use serial_test::serial;
 
     fn mixsinx(x: &ArrayView2<f64>) -> Array2<f64> {
         if (x.mapv(|v| v.round()).norm_l2() - x.norm_l2()).abs() < 1e-6 {
@@ -97,15 +105,16 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_mixintegor_ei() {
-        let n_eval = 10;
+        let n_eval = 30;
         let doe = array![[0.], [7.], [25.]];
         let xtypes = vec![Xtype::Int(0, 25)];
 
         let surrogate_builder = MoeParams::default();
         let surrogate_builder = MixintMoeParams::new(&xtypes, &surrogate_builder);
-        let evaluator = MixintEvaluator::new(&xtypes);
-        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &evaluator);
+        let pre_proc = MixintPreProcessor::new(&xtypes);
+        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &pre_proc);
         mixintegor
             .egor
             .doe(Some(doe))
@@ -116,29 +125,26 @@ mod tests {
             }))
             .infill_strategy(InfillStrategy::EI);
 
-        let res = mixintegor.minimize();
-        println!("{:?}", res)
+        let res = mixintegor.minimize().unwrap();
+        assert_abs_diff_eq!(array![18.], res.x_opt, epsilon = 2.);
     }
 
     #[test]
+    #[serial]
     fn test_mixintegor_wb2() {
-        let n_eval = 10;
+        let n_eval = 30;
         let xtypes = vec![Xtype::Int(0, 25)];
 
         let surrogate_builder = MoeParams::default();
         let surrogate_builder = MixintMoeParams::new(&xtypes, &surrogate_builder);
-        let evaluator = MixintEvaluator::new(&xtypes);
-        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &evaluator);
+        let pre_proc = MixintPreProcessor::new(&xtypes);
+        let mut mixintegor = MixintEgor::new(mixsinx, &surrogate_builder, &pre_proc);
         mixintegor
             .egor
             .n_eval(n_eval)
-            .expect(Some(ApproxValue {
-                value: -15.1,
-                tolerance: 1e-1,
-            }))
             .infill_strategy(InfillStrategy::WB2);
 
-        let res = mixintegor.minimize();
-        println!("{:?}", res)
+        let res = mixintegor.minimize().unwrap();
+        assert_abs_diff_eq!(&array![18.], &res.x_opt, epsilon = 2.);
     }
 }

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -1,3 +1,5 @@
+use crate::errors::Result;
+use egobox_moe::Surrogate;
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
 
@@ -36,8 +38,30 @@ pub enum QEiStrategy {
     ConstantLiarMinimum,
 }
 
+/// A structure to specify an approximative value
+#[derive(Clone, Copy, Debug)]
+pub struct ApproxValue {
+    /// Nominal value
+    pub value: f64,
+    /// Allowed tolerance for approximation such that (y - value) < tolerance
+    pub tolerance: f64,
+}
+
 /// An interface for objective function to be optimized
 /// The function is expected to return a matrix allowing nrows evaluations at once.
 /// A row of the output matrix is expected to contain [objective, cstr_1, ... cstr_n] values.
 pub trait GroupFunc: Send + Sync + 'static + Clone + Fn(&ArrayView2<f64>) -> Array2<f64> {}
 impl<T> GroupFunc for T where T: Send + Sync + 'static + Clone + Fn(&ArrayView2<f64>) -> Array2<f64> {}
+
+/// A trait for surrogate training
+/// The output surrogate used by [Egor] is expected to model either
+/// objective function or constraint functions
+pub trait SurrogateBuilder {
+    /// Train the surrogate with given training dataset (x, y)
+    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn Surrogate>>;
+}
+
+/// An interface for "function under optimization" evaluation
+pub trait Evaluator {
+    fn eval(&self, x: &Array2<f64>) -> Array2<f64>;
+}

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -62,6 +62,6 @@ pub trait SurrogateBuilder {
 }
 
 /// An interface for "function under optimization" evaluation
-pub trait Evaluator {
+pub trait PreProcessor {
     fn eval(&self, x: &Array2<f64>) -> Array2<f64>;
 }

--- a/gp/src/correlation_models.rs
+++ b/gp/src/correlation_models.rs
@@ -1,5 +1,5 @@
-//! A module for correlation models which implements PLS weighting used by GP models.
-//! The following kernels are implemented:
+//! A module for correlation models with PLS weighting to model the error term of the GP model.
+//! The following correlation models are implemented:
 //! * squared exponential,
 //! * absolute exponential,
 //! * matern 3/2,

--- a/gp/src/mean_models.rs
+++ b/gp/src/mean_models.rs
@@ -1,4 +1,6 @@
-//! A module for regression models used by GP models.
+//! A module for regression models to model the mean term of the GP model.
+//! In practice small degree (<= 2) polynomial regression models are used,
+//! as the gaussian process is then fitted using the [correlated error term](struct.CorrelationModel).
 //! The following models are implemented:
 //! * constant,
 //! * linear,
@@ -10,7 +12,7 @@ use ndarray::{concatenate, s, Array2, ArrayBase, Axis, Data, Ix2};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-/// A trait for using a correlation model in GP regression
+/// A trait for mean models used in GP regression
 pub trait RegressionModel<F: Float>: Clone + Copy + Default {
     /// Use the regression model to get the mean behaviour of the GP model.
     fn apply(&self, x: &ArrayBase<impl Data<Elem = F>, Ix2>) -> Array2<F>;

--- a/moe/src/clustering.rs
+++ b/moe/src/clustering.rs
@@ -299,7 +299,6 @@ pub fn find_best_number_of_clusters<R: Rng + SeedableRng + Clone>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parameters::MoeFit;
     use approx::assert_abs_diff_eq;
     use egobox_doe::{FullFactorial, Lhs, SamplingMethod};
     use ndarray::{array, Array1, Array2, Axis, Zip};
@@ -346,10 +345,10 @@ mod tests {
         );
         let moe = Moe::params(nb_clusters)
             .recombination(recombination)
-            .train(&xtrain, &ytrain)
+            .fit(&Dataset::new(xtrain, ytrain))
             .unwrap();
         let obs = Array1::linspace(0., 1., 100).insert_axis(Axis(1));
-        let preds = moe.predict_values(&obs.view()).unwrap();
+        let preds = moe.predict_values(&obs).unwrap();
         write_npy("best_obs.npy", &obs).expect("saved");
         write_npy("best_preds.npy", &preds).expect("saved");
         assert_eq!(3, nb_clusters);
@@ -374,9 +373,9 @@ mod tests {
         let yvalid = l1norm(&xvalid);
         let moe = Moe::params(n_clusters)
             .recombination(recomb)
-            .train(&xtrain, &ytrain)
+            .fit(&Dataset::new(xtrain, ytrain))
             .unwrap();
-        let ypreds = moe.predict_values(&xvalid.view()).expect("moe not fitted");
+        let ypreds = moe.predict_values(&xvalid).expect("moe not fitted");
         debug!("{:?}", concatenate![Axis(1), ypreds, yvalid]);
         assert_abs_diff_eq!(&ypreds, &yvalid, epsilon = 1e-2);
     }

--- a/moe/src/parameters.rs
+++ b/moe/src/parameters.rs
@@ -1,5 +1,4 @@
 use crate::errors::{MoeError, Result};
-use crate::surrogates::Surrogate;
 use bitflags::bitflags;
 #[allow(unused_imports)]
 use egobox_gp::correlation_models::{
@@ -9,7 +8,6 @@ use egobox_gp::correlation_models::{
 use egobox_gp::mean_models::{ConstantMean, LinearMean, QuadraticMean};
 use linfa::{Float, ParamGuard};
 use linfa_clustering::GaussianMixtureModel;
-use ndarray::Array2;
 use ndarray_rand::rand::{Rng, SeedableRng};
 use rand_isaac::Isaac64Rng;
 
@@ -76,12 +74,6 @@ bitflags! {
                     | CorrelationSpec::MATERN32.bits
                     | CorrelationSpec::MATERN52.bits;
     }
-}
-
-/// A trait for mixture of experts predictor construction (model fitting)
-pub trait MoeFit {
-    /// Train the mixture of models with given training dataset (x, y)
-    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn Surrogate>>;
 }
 
 /// Mixture of experts checked parameters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,17 +474,17 @@ impl Egor {
             })
             .collect();
 
-        let moe_params = egobox_moe::MoeParams::default()
+        let surrogate_builder = egobox_moe::MoeParams::default()
             .nclusters(self.n_clusters.unwrap_or(1))
             .kpls_dim(self.kpls_dim)
             .regression_spec(egobox_moe::RegressionSpec::from_bits(self.regression_spec.0).unwrap())
             .correlation_spec(
                 egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
             );
-        let moe_params = egobox_ego::MixintMoeParams::new(&xtypes, &moe_params);
+        let surrogate_builder = egobox_ego::MixintMoeParams::new(&xtypes, &surrogate_builder);
         let evaluator = egobox_ego::MixintEvaluator::new(&xtypes);
         let mut mixintegor =
-            egobox_ego::MixintEgor::new_with_rng(obj, &moe_params, &evaluator, rng);
+            egobox_ego::MixintEgor::new_with_rng(obj, &surrogate_builder, &evaluator, rng);
         mixintegor
             .egor
             .n_cstr(self.n_cstr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,9 +482,9 @@ impl Egor {
                 egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
             );
         let surrogate_builder = egobox_ego::MixintMoeParams::new(&xtypes, &surrogate_builder);
-        let evaluator = egobox_ego::MixintEvaluator::new(&xtypes);
+        let pre_proc = egobox_ego::MixintPreProcessor::new(&xtypes);
         let mut mixintegor =
-            egobox_ego::MixintEgor::new_with_rng(obj, &surrogate_builder, &evaluator, rng);
+            egobox_ego::MixintEgor::new_with_rng(obj, &surrogate_builder, &pre_proc, rng);
         mixintegor
             .egor
             .n_cstr(self.n_cstr)


### PR DESCRIPTION
- [x] Extract and rename `MoeFit` in `ego` as `SurrogateBuilder`
- [x] Implement `SurrogateBuilder` for `MoeParams` in `ego`
- [x] Remove `train` from Moe public interface use only `fit`
- [x] Improve doc