### PR TITLE
Implement automatic reclustering

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -619,7 +619,8 @@ impl<'a, O: GroupFunc, R: Rng + Clone> Egor<'a, O, R> {
             if self.should_recluster(n_iter) {
                 info!("Constraint[{}] reclustering...", k)
             }
-            let cstr_model = self.make_clustered_surrogate(x_data, y_data, n_iter, &clusterings[k]);
+            let cstr_model =
+                self.make_clustered_surrogate(x_data, y_data, n_iter, &clusterings[k + 1]);
             cstr_models.push(cstr_model);
             if self.should_recluster(n_iter) {
                 info!(

--- a/ego/src/lib.rs
+++ b/ego/src/lib.rs
@@ -42,6 +42,7 @@
 //!  
 //! ```no_run   
 //! use ndarray::{array, Array2, ArrayView2};
+//! use linfa::ParamGuard;
 //! #[cfg(feature = "blas")]
 //! use ndarray_linalg::Norm;
 //! #[cfg(not(feature = "blas"))]
@@ -64,7 +65,9 @@
 //! let xtypes = vec![Xtype::Int(0, 25)];
 //!
 //! // We create mixed-integer mixture of experts
-//! let surrogate_builder = MixintMoeParams::new(&xtypes, &MoeParams::default());
+//! let surrogate_builder = MixintMoeParams::new(&xtypes, &MoeParams::default())
+//!                           .check()
+//!                           .expect("Mixint Moe params validation");
 //!
 //! // We use a mixint pre-processor which cast continuous values to discrete
 //! // and evaluate function under optimization

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use egobox_moe::Surrogate;
+use egobox_moe::ClusteredSurrogate;
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
 
@@ -69,7 +69,7 @@ impl<T> GroupFunc for T where T: Send + Sync + 'static + Clone + Fn(&ArrayView2<
 /// objective function or constraint functions
 pub trait SurrogateBuilder {
     /// Train the surrogate with given training dataset (x, y)
-    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn Surrogate>>;
+    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn ClusteredSurrogate>>;
 }
 
 /// An interface for preprocessing continuous input init_values

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -1,5 +1,5 @@
 use crate::errors::Result;
-use egobox_moe::ClusteredSurrogate;
+use egobox_moe::{ClusteredSurrogate, Clustering};
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
 
@@ -70,6 +70,14 @@ impl<T> GroupFunc for T where T: Send + Sync + 'static + Clone + Fn(&ArrayView2<
 pub trait SurrogateBuilder {
     /// Train the surrogate with given training dataset (x, y)
     fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Box<dyn ClusteredSurrogate>>;
+
+    /// Train the surrogate with given training dataset (x, y) and given clustering
+    fn train_on_clusters(
+        &self,
+        xt: &Array2<f64>,
+        yt: &Array2<f64>,
+        clustering: &Clustering,
+    ) -> Result<Box<dyn ClusteredSurrogate>>;
 }
 
 /// An interface for preprocessing continuous input init_values

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -1,4 +1,4 @@
-use egobox_moe::Surrogate;
+use egobox_moe::ClusteredSurrogate;
 use libm::erfc;
 use ndarray::{
     concatenate, Array1, Array2, ArrayBase, ArrayView, ArrayView2, Axis, Data, Ix1, Ix2, Zip,
@@ -10,7 +10,7 @@ use ndarray_stats::{DeviationExt, QuantileExt};
 
 const SQRT_2PI: f64 = 2.5066282746310007;
 
-pub fn ei(x: &[f64], obj_model: &dyn Surrogate, f_min: f64) -> f64 {
+pub fn ei(x: &[f64], obj_model: &dyn ClusteredSurrogate, f_min: f64) -> f64 {
     let pt = ArrayView::from_shape((1, x.len()), x).unwrap();
     if let Ok(p) = obj_model.predict_values(&pt) {
         if let Ok(s) = obj_model.predict_variances(&pt) {
@@ -28,13 +28,17 @@ pub fn ei(x: &[f64], obj_model: &dyn Surrogate, f_min: f64) -> f64 {
     }
 }
 
-pub fn wb2s(x: &[f64], obj_model: &dyn Surrogate, f_min: f64, scale: f64) -> f64 {
+pub fn wb2s(x: &[f64], obj_model: &dyn ClusteredSurrogate, f_min: f64, scale: f64) -> f64 {
     let pt = ArrayView::from_shape((1, x.len()), x).unwrap();
     let ei = ei(x, obj_model, f_min);
     scale * ei - obj_model.predict_values(&pt).unwrap()[[0, 0]]
 }
 
-pub fn compute_wb2s_scale(x: &ArrayView2<f64>, obj_model: &dyn Surrogate, f_min: f64) -> f64 {
+pub fn compute_wb2s_scale(
+    x: &ArrayView2<f64>,
+    obj_model: &dyn ClusteredSurrogate,
+    f_min: f64,
+) -> f64 {
     let ratio = 100.; // TODO: make it a parameter
     let ei_x = x.map_axis(Axis(1), |xi| {
         let ei = ei(xi.as_slice().unwrap(), obj_model, f_min);
@@ -52,12 +56,15 @@ pub fn compute_wb2s_scale(x: &ArrayView2<f64>, obj_model: &dyn Surrogate, f_min:
     }
 }
 
-pub fn compute_obj_scale(x: &ArrayView2<f64>, obj_model: &dyn Surrogate) -> f64 {
+pub fn compute_obj_scale(x: &ArrayView2<f64>, obj_model: &dyn ClusteredSurrogate) -> f64 {
     let preds = obj_model.predict_values(x).unwrap().mapv(f64::abs);
     *preds.max().unwrap_or(&1.0)
 }
 
-pub fn compute_cstr_scales(x: &ArrayView2<f64>, cstr_models: &[Box<dyn Surrogate>]) -> Array1<f64> {
+pub fn compute_cstr_scales(
+    x: &ArrayView2<f64>,
+    cstr_models: &[Box<dyn ClusteredSurrogate>],
+) -> Array1<f64> {
     let scales: Vec<f64> = cstr_models
         .iter()
         .map(|cstr_model| {

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -163,16 +163,14 @@ impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
                 .n_clusters(gmx.n_clusters())
                 .recombination(Recombination::Smooth(Some(factor)))
                 .check()?
-                .train(xt, yt)
-            // TODO: See if we can use training on clusters
-            // .train_on_clusters(
-            //     xt,
-            //     yt,
-            //     &Clustering::new(
-            //         gmx.clone().with_heaviside_factor(factor),
-            //         Recombination::Smooth(Some(factor)),
-            //     ),
-            // )
+                .train_on_clusters(
+                    xt,
+                    yt,
+                    &Clustering::new(
+                        gmx.clone().with_heaviside_factor(factor),
+                        Recombination::Smooth(Some(factor)),
+                    ),
+                )
         } else {
             Ok(Moe {
                 recombination: recomb,

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -372,6 +372,15 @@ impl std::fmt::Display for Moe {
     }
 }
 
+impl Clustered for Moe {
+    /// Number of clusters
+    fn n_clusters(&self) -> usize {
+        self.experts.len()
+    }
+}
+
+impl ClusteredSurrogate for Moe {}
+
 #[cfg_attr(feature = "persistent", typetag::serde)]
 impl Surrogate for Moe {
     fn predict_values(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
@@ -405,11 +414,6 @@ impl Moe {
     /// Constructor of mixture of experts parameters
     pub fn params() -> MoeParams<f64, Isaac64Rng> {
         MoeParams::new()
-    }
-
-    /// Number of clusters
-    pub fn n_clusters(&self) -> usize {
-        self.experts.len()
     }
 
     /// Recombination mode

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -1,5 +1,5 @@
 use super::gaussian_mixture::GaussianMixture;
-use crate::clustering::find_best_number_of_clusters;
+use crate::clustering::{find_best_number_of_clusters, Clustered, Clustering};
 use crate::errors::MoeError;
 use crate::errors::Result;
 use crate::expertise_macros::*;
@@ -64,12 +64,10 @@ impl<R: Rng + SeedableRng + Clone> Fit<Array2<f64>, Array2<f64>, MoeError>
 }
 
 impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
-    fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Moe> {
+    pub fn train(&self, xt: &Array2<f64>, yt: &Array2<f64>) -> Result<Moe> {
         let _opt = env_logger::try_init().ok();
         let nx = xt.ncols();
         let data = concatenate(Axis(1), &[xt.view(), yt.view()]).unwrap();
-        let training;
-        let (mut xtest, mut ytest) = (None, None);
 
         let (n_clusters, recomb) = if self.n_clusters() == 0 {
             // automatic mode
@@ -89,19 +87,16 @@ impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
         if self.n_clusters() == 0 {
             debug!("Automatic settings {} {:?}", n_clusters, recomb);
         }
-        if let Recombination::Smooth(None) = recomb {
+
+        let training = if let Recombination::Smooth(None) = recomb {
             // Extract 5% of data for validation
             // TODO: Use cross-validation ? Performances
-            let (test, training_data) = extract_part(&data, 5);
-            // write_npy("xt_hard.npy", &training.slice(s![.., ..nx])).expect("obs saved");
-            // write_npy("yt_hard.npy", &training.slice(s![.., nx..])).expect("preds saved");
+            let (_, training_data) = extract_part(&data, 5);
 
-            xtest = Some(test.slice(s![.., ..nx]).to_owned());
-            ytest = Some(test.slice(s![.., nx..]).to_owned());
-            training = training_data;
+            training_data
         } else {
-            training = data.to_owned();
-        }
+            data.to_owned()
+        };
         let dataset = Dataset::from(training);
 
         let gmm = GaussianMixtureModel::params(n_clusters)
@@ -121,8 +116,24 @@ impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
         };
         let gmx = GaussianMixture::new(weights, means, covariances)?.with_heaviside_factor(factor);
 
+        let clustering = Clustering::new(gmx, recomb);
+        self.train_on_clusters(xt, yt, &clustering)
+    }
+
+    pub fn train_on_clusters(
+        &self,
+        xt: &Array2<f64>,
+        yt: &Array2<f64>,
+        clustering: &Clustering,
+    ) -> Result<Moe> {
+        let gmx = clustering.gmx();
+        let recomb = clustering.recombination();
+        let _opt = env_logger::try_init().ok();
+        let nx = xt.ncols();
+        let data = concatenate(Axis(1), &[xt.view(), yt.view()]).unwrap();
+
         let dataset_clustering = gmx.predict(xt);
-        let clusters = sort_by_cluster(n_clusters, &data, &dataset_clustering);
+        let clusters = sort_by_cluster(gmx.n_clusters(), &data, &dataset_clustering);
 
         check_number_of_points(&clusters, xt.ncols())?;
 
@@ -141,18 +152,23 @@ impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
         }
 
         if recomb == Recombination::Smooth(None) {
+            // Extract 5% of data for validation
+            // TODO: Use cross-validation ? Performances
+            let (test, _) = extract_part(&data, 5);
+            let xtest = Some(test.slice(s![.., ..nx]).to_owned());
+            let ytest = Some(test.slice(s![.., nx..]).to_owned());
             let factor =
-                self.optimize_heaviside_factor(&experts, &gmx, &xtest.unwrap(), &ytest.unwrap());
+                self.optimize_heaviside_factor(&experts, gmx, &xtest.unwrap(), &ytest.unwrap());
             MoeParams::from(self.clone())
-                .n_clusters(n_clusters)
+                .n_clusters(gmx.n_clusters())
                 .recombination(Recombination::Smooth(Some(factor)))
                 .check()?
-                .train(xt, yt)
+                .train_on_clusters(xt, yt, &Clustering::new(gmx.clone(), recomb))
         } else {
             Ok(Moe {
                 recombination: recomb,
                 experts,
-                gmx,
+                gmx: gmx.clone(),
             })
         }
     }
@@ -375,11 +391,17 @@ impl std::fmt::Display for Moe {
 impl Clustered for Moe {
     /// Number of clusters
     fn n_clusters(&self) -> usize {
-        self.experts.len()
+        self.gmx.n_clusters()
+    }
+
+    /// Convert to clustering
+    fn to_clustering(&self) -> Clustering {
+        Clustering {
+            recombination: self.recombination(),
+            gmx: self.gmx.clone(),
+        }
     }
 }
-
-impl ClusteredSurrogate for Moe {}
 
 #[cfg_attr(feature = "persistent", typetag::serde)]
 impl Surrogate for Moe {
@@ -410,6 +432,10 @@ impl Surrogate for Moe {
     }
 }
 
+pub trait ClusteredSurrogate: Clustered + Surrogate {}
+
+impl ClusteredSurrogate for Moe {}
+
 impl Moe {
     /// Constructor of mixture of experts parameters
     pub fn params() -> MoeParams<f64, Isaac64Rng> {
@@ -419,6 +445,11 @@ impl Moe {
     /// Recombination mode
     pub fn recombination(&self) -> Recombination<f64> {
         self.recombination
+    }
+
+    /// Recombination mode
+    pub fn gmx(&self) -> &GaussianMixture<f64> {
+        &self.gmx
     }
 
     /// Sets recombination mode

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -163,7 +163,16 @@ impl<R: Rng + SeedableRng + Clone> MoeValidParams<f64, R> {
                 .n_clusters(gmx.n_clusters())
                 .recombination(Recombination::Smooth(Some(factor)))
                 .check()?
-                .train_on_clusters(xt, yt, &Clustering::new(gmx.clone(), recomb))
+                .train(xt, yt)
+            // TODO: See if we can use training on clusters
+            // .train_on_clusters(
+            //     xt,
+            //     yt,
+            //     &Clustering::new(
+            //         gmx.clone().with_heaviside_factor(factor),
+            //         Recombination::Smooth(Some(factor)),
+            //     ),
+            // )
         } else {
             Ok(Moe {
                 recombination: recomb,

--- a/moe/src/clustering.rs
+++ b/moe/src/clustering.rs
@@ -8,7 +8,7 @@ use linfa::dataset::{Dataset, DatasetView};
 use linfa::traits::{Fit, Predict};
 use linfa_clustering::GaussianMixtureModel;
 use ndarray::{concatenate, ArrayBase, Axis, Data, Ix2};
-use ndarray_rand::rand::{Rng, SeedableRng};
+use ndarray_rand::rand::Rng;
 use std::ops::Sub;
 
 fn mean(list: &[f64]) -> f64 {
@@ -29,7 +29,7 @@ fn median(v: &[f64]) -> f64 {
 }
 
 /// Find the best number of cluster thanks to cross validation
-pub fn find_best_number_of_clusters<R: Rng + SeedableRng + Clone>(
+pub fn find_best_number_of_clusters<R: Rng + Clone>(
     x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     y: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     max_nb_clusters: usize,

--- a/moe/src/clustering.rs
+++ b/moe/src/clustering.rs
@@ -11,6 +11,31 @@ use ndarray::{concatenate, ArrayBase, Axis, Data, Ix2};
 use ndarray_rand::rand::Rng;
 use std::ops::Sub;
 
+pub trait Clustered {
+    fn n_clusters(&self) -> usize;
+
+    fn to_clustering(&self) -> Clustering;
+}
+
+#[derive(Clone)]
+pub struct Clustering {
+    pub(crate) recombination: Recombination<f64>,
+    pub(crate) gmx: GaussianMixture<f64>,
+}
+
+impl Clustering {
+    pub fn new(gmx: GaussianMixture<f64>, recombination: Recombination<f64>) -> Self {
+        Clustering { gmx, recombination }
+    }
+
+    pub fn recombination(&self) -> Recombination<f64> {
+        self.recombination
+    }
+    pub fn gmx(&self) -> &GaussianMixture<f64> {
+        &self.gmx
+    }
+}
+
 fn mean(list: &[f64]) -> f64 {
     let sum: f64 = Iterator::sum(list.iter());
     sum / (list.len() as f64)

--- a/moe/src/gaussian_mixture.rs
+++ b/moe/src/gaussian_mixture.rs
@@ -58,6 +58,10 @@ impl<F: Float> GaussianMixture<F> {
         })
     }
 
+    pub fn n_clusters(&self) -> usize {
+        self.weights.len()
+    }
+
     pub fn weights(&self) -> &Array1<F> {
         &self.weights
     }

--- a/moe/src/gaussian_mixture.rs
+++ b/moe/src/gaussian_mixture.rs
@@ -17,6 +17,7 @@ use ndarray_stats::QuantileExt;
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "persistent", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct GaussianMixture<F: Float> {
     weights: Array1<F>,
     means: Array2<F>,

--- a/moe/src/lib.rs
+++ b/moe/src/lib.rs
@@ -106,6 +106,7 @@ mod parameters;
 mod surrogates;
 
 pub use algorithm::*;
+pub use clustering::*;
 pub use errors::*;
 pub use parameters::*;
 pub use surrogates::*;

--- a/moe/src/lib.rs
+++ b/moe/src/lib.rs
@@ -108,5 +108,6 @@ mod surrogates;
 pub use algorithm::*;
 pub use clustering::*;
 pub use errors::*;
+pub use gaussian_mixture::*;
 pub use parameters::*;
 pub use surrogates::*;

--- a/moe/src/surrogates.rs
+++ b/moe/src/surrogates.rs
@@ -36,6 +36,12 @@ pub trait Surrogate: std::fmt::Display {
     fn save(&self, path: &str) -> Result<()>;
 }
 
+pub trait Clustered {
+    fn n_clusters(&self) -> usize;
+}
+
+pub trait ClusteredSurrogate: Surrogate + Clustered {}
+
 /// A macro to declare GP surrogate using regression model and correlation model names.
 ///
 /// Regression model is either `Constant`, `Linear` or `Quadratic`.

--- a/moe/src/surrogates.rs
+++ b/moe/src/surrogates.rs
@@ -36,12 +36,6 @@ pub trait Surrogate: std::fmt::Display {
     fn save(&self, path: &str) -> Result<()>;
 }
 
-pub trait Clustered {
-    fn n_clusters(&self) -> usize;
-}
-
-pub trait ClusteredSurrogate: Surrogate + Clustered {}
-
 /// A macro to declare GP surrogate using regression model and correlation model names.
 ///
 /// Regression model is either `Constant`, `Linear` or `Quadratic`.

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -85,6 +85,13 @@ class TestOptimizer(unittest.TestCase):
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-3)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
 
+    def test_xsinx_with_reclustering(self):
+        egor = egx.Egor(xsinx, egx.to_specs([[0.0, 25.0]]), seed=42, n_clusters=0)
+        res = egor.minimize(n_eval=20)
+        print(f"Optimization f={res.y_opt} at {res.x_opt}")
+        self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-3)
+        self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
+
     def test_xsinx_with_hotstart(self):
         xlimits = egx.to_specs([[0.0, 25.0]])
         doe = egx.lhs(xlimits, 10)
@@ -96,7 +103,7 @@ class TestOptimizer(unittest.TestCase):
 
         ydoe = xsinx(doe)
         doe = np.hstack((doe, ydoe))
-        egor = egx.Egor(xsinx, xlimits, doe=doe, outdir="./test_dir", hot_start=True)
+        egor = egx.Egor(xsinx, xlimits, outdir="./test_dir", hot_start=True)
         res = egor.minimize(n_eval=5)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //!
 
 use egobox_doe::SamplingMethod;
+use linfa::ParamGuard;
 use ndarray::{Array2, ArrayView2};
 use ndarray_rand::rand::SeedableRng;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
@@ -377,7 +378,7 @@ impl Egor {
         }
     }
 
-    /// This function finds the minimum of a given fun function
+    /// This function finds the minimum of a given function `fun`
     ///
     /// # Parameters
     ///     n_eval:
@@ -481,7 +482,9 @@ impl Egor {
             .correlation_spec(
                 egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
             );
-        let surrogate_builder = egobox_ego::MixintMoeParams::new(&xtypes, &surrogate_builder);
+        let surrogate_builder = egobox_ego::MixintMoeParams::new(&xtypes, &surrogate_builder)
+            .check()
+            .unwrap();
         let pre_proc = egobox_ego::MixintPreProcessor::new(&xtypes);
         let mut mixintegor =
             egobox_ego::MixintEgor::new_with_rng(obj, &surrogate_builder, &pre_proc, rng);


### PR DESCRIPTION
Use MoE auto-clustering to implement automatic reclustering during optimization.
When number of clusters is set to 0 in Egor constructor, MoE models are clustered automatically initially and after every 10-points addition.
