### PR TITLE
Kriging derivatives

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -236,8 +236,8 @@ impl<'a, O: GroupFunc, R: Rng + SeedableRng + Clone> Egor<'a, O, R> {
             q_ei: QEiStrategy::KrigingBeliever,
             infill: InfillStrategy::WB2,
             infill_optimizer: InfillOptimizer::Slsqp,
-            regression_spec: RegressionSpec::ALL,
-            correlation_spec: CorrelationSpec::ALL,
+            regression_spec: RegressionSpec::CONSTANT,
+            correlation_spec: CorrelationSpec::SQUAREDEXPONENTIAL,
             kpls_dim: None,
             n_clusters: Some(1),
             expected: None,
@@ -1110,8 +1110,6 @@ mod tests {
         let initial_doe = array![[0.], [7.], [25.]];
         let res = Egor::new(xsinx, &array![[0.0, 25.0]])
             .infill_strategy(InfillStrategy::EI)
-            .regression_spec(RegressionSpec::CONSTANT)
-            .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
             .n_eval(20)
             .doe(Some(initial_doe.to_owned()))
             .expect(Some(ApproxValue {
@@ -1129,6 +1127,8 @@ mod tests {
     fn test_xsinx_wb2() {
         let res = Egor::new(xsinx, &array![[0.0, 25.0]])
             .n_eval(20)
+            .regression_spec(RegressionSpec::ALL)
+            .correlation_spec(CorrelationSpec::ALL)
             .minimize()
             .expect("Minimize failure");
         let expected = array![18.9];
@@ -1211,6 +1211,8 @@ mod tests {
             .with_rng(Isaac64Rng::seed_from_u64(42))
             .doe(Some(doe))
             .n_eval(100)
+            .regression_spec(RegressionSpec::ALL)
+            .correlation_spec(CorrelationSpec::ALL)
             .expect(Some(ApproxValue {
                 value: 0.0,
                 tolerance: 1e-2,
@@ -1226,6 +1228,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_deriv_rosenbrock_2d() {
+        // true deriv of criteria is implemented for kriging surrogate (default surrogate used by optimizer)
         let now = Instant::now();
         let xlimits = array![[-2., 2.], [-2., 2.]];
         let doe = Lhs::new(&xlimits)
@@ -1236,8 +1239,6 @@ mod tests {
             .doe(Some(doe))
             .n_eval(100)
             .infill_strategy(InfillStrategy::EI)
-            .regression_spec(RegressionSpec::CONSTANT)
-            .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
             .expect(Some(ApproxValue {
                 value: 0.0,
                 tolerance: 1e-2,

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -94,9 +94,9 @@ use crate::errors::{EgoError, Result};
 use crate::lhs_optimizer::LhsOptimizer;
 use crate::sort_axis::*;
 use crate::types::*;
-use crate::utils::update_data;
-use crate::utils::{compute_cstr_scales, compute_obj_scale, compute_wb2s_scale};
+use crate::utils::{compute_cstr_scales, compute_obj_scale, compute_wb2s_scale, grad_wbs2};
 use crate::utils::{ei, wb2s};
+use crate::utils::{grad_ei, update_data};
 
 use egobox_doe::{Lhs, LhsKind, SamplingMethod};
 use egobox_moe::{ClusteredSurrogate, Clustering, CorrelationSpec, Moe, MoeParams, RegressionSpec};
@@ -813,6 +813,11 @@ impl<'a, O: GroupFunc, R: Rng + SeedableRng + Clone> Egor<'a, O, R> {
                 let f = |x: &Vec<f64>| -> f64 {
                     self.infill_eval(x, obj_model, *f_min, *scale_obj, *scale_wb2)
                 };
+                // let grd = self
+                //     .grad_infill_eval(x, obj_model, *f_min, *scale_obj, *scale_wb2)
+                //     .to_vec();
+                // info!("finite diff {:?}", x.to_vec().forward_diff(&f));
+                // info!("gradient {:?}", grd);
                 grad[..].copy_from_slice(&x.to_vec().central_diff(&f));
             }
             self.infill_eval(x, obj_model, *f_min, *scale_obj, *scale_wb2)
@@ -1010,6 +1015,23 @@ impl<'a, O: GroupFunc, R: Rng + SeedableRng + Clone> Egor<'a, O, R> {
         obj / scale
     }
 
+    pub fn grad_infill_eval(
+        &self,
+        x: &[f64],
+        obj_model: &dyn ClusteredSurrogate,
+        f_min: f64,
+        scale: f64,
+        scale_wb2: f64,
+    ) -> Vec<f64> {
+        let x_f = x.to_vec();
+        let grad = match self.infill {
+            InfillStrategy::EI => -grad_ei(&x_f, obj_model, f_min),
+            InfillStrategy::WB2 => -grad_wbs2(&x_f, obj_model, f_min, 1.),
+            InfillStrategy::WB2S => -grad_wbs2(&x_f, obj_model, f_min, scale_wb2),
+        };
+        (grad / scale).to_vec()
+    }
+
     fn eval(&self, x: &Array2<f64>) -> Array2<f64> {
         if let Some(pre_proc) = self.pre_proc {
             (self.obj)(&pre_proc.run(x).view())
@@ -1055,6 +1077,25 @@ mod tests {
         let saved_doe: Array2<f64> =
             read_npy(format!("target/tests/{}", DOE_INITIAL_FILE)).unwrap();
         assert_abs_diff_eq!(initial_doe, saved_doe.slice(s![..3, ..1]), epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_deriv() {
+        let initial_doe = array![[0.], [7.], [25.]];
+        let res = Egor::new(xsinx, &array![[0.0, 25.0]])
+            .infill_strategy(InfillStrategy::EI)
+            .regression_spec(RegressionSpec::CONSTANT)
+            .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
+            .n_eval(20)
+            .doe(Some(initial_doe.to_owned()))
+            .expect(Some(ApproxValue {
+                value: -15.1,
+                tolerance: 1e-1,
+            }))
+            .minimize()
+            .expect("Minimization");
+        let expected = array![-15.1];
+        assert_abs_diff_eq!(expected, res.y_opt, epsilon = 0.5);
     }
 
     #[test]
@@ -1144,6 +1185,33 @@ mod tests {
             .with_rng(Isaac64Rng::seed_from_u64(42))
             .doe(Some(doe))
             .n_eval(100)
+            .expect(Some(ApproxValue {
+                value: 0.0,
+                tolerance: 1e-2,
+            }))
+            .minimize()
+            .expect("Minimize failure");
+        println!("Rosenbrock optim result = {:?}", res);
+        println!("Elapsed = {:?}", now.elapsed());
+        let expected = array![1., 1.];
+        assert_abs_diff_eq!(expected, res.x_opt, epsilon = 5e-1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_deriv_rosenbrock_2d() {
+        let now = Instant::now();
+        let xlimits = array![[-2., 2.], [-2., 2.]];
+        let doe = Lhs::new(&xlimits)
+            .with_rng(Isaac64Rng::seed_from_u64(42))
+            .sample(10);
+        let res = Egor::new(rosenb, &xlimits)
+            .with_rng(Isaac64Rng::seed_from_u64(42))
+            .doe(Some(doe))
+            .n_eval(100)
+            .infill_strategy(InfillStrategy::EI)
+            .regression_spec(RegressionSpec::CONSTANT)
+            .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
             .expect(Some(ApproxValue {
                 value: 0.0,
                 tolerance: 1e-2,

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -623,13 +623,13 @@ mod tests {
             .expect("Predict var fail");
         println!("{:?}", ytest);
         assert_abs_diff_eq!(
-            array![[0.], [0.8296067096163109], [1.5], [0.9], [1.]],
+            array![[0.], [0.8297580023632912], [1.5], [0.9], [1.]],
             ytest,
-            epsilon = 1e-6
+            epsilon = 1e-3
         );
         println!("{:?}", yvar);
         assert_abs_diff_eq!(
-            array![[0.], [0.35290670137172425], [0.], [0.], [0.]],
+            array![[0.], [0.35300898770096056], [0.], [0.], [0.]],
             yvar,
             epsilon = 1e-6
         );

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -452,6 +452,26 @@ impl Surrogate for MixintMoe {
         self.moe.predict_variances(&xcast)
     }
 
+    fn predict_jacobian(&self, x: &ArrayView2<f64>) -> egobox_moe::Result<Array2<f64>> {
+        let mut xcast = if self.work_in_folded_space {
+            unfold_with_enum_mask(&self.xtypes, x)
+        } else {
+            x.to_owned()
+        };
+        cast_to_discrete_values_mut(&self.xtypes, &mut xcast);
+        self.moe.predict_jacobian(&xcast)
+    }
+
+    fn predict_variance_jacobian(&self, x: &ArrayView2<f64>) -> egobox_moe::Result<Array2<f64>> {
+        let mut xcast = if self.work_in_folded_space {
+            unfold_with_enum_mask(&self.xtypes, x)
+        } else {
+            x.to_owned()
+        };
+        cast_to_discrete_values_mut(&self.xtypes, &mut xcast);
+        self.moe.predict_variance_jacobian(&xcast)
+    }
+
     /// Save Moe model in given file.
     #[cfg(feature = "persistent")]
     fn save(&self, path: &str) -> egobox_moe::Result<()> {

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -174,7 +174,7 @@ mod tests {
     use egobox_doe::SamplingMethod;
     use egobox_moe::*;
     use linfa::prelude::*;
-    use ndarray::{array, Array};
+    use ndarray::array;
 
     #[test]
     fn test_is_update_ok() {

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -28,10 +28,56 @@ pub fn ei(x: &[f64], obj_model: &dyn ClusteredSurrogate, f_min: f64) -> f64 {
     }
 }
 
+pub fn grad_ei(x: &[f64], obj_model: &dyn ClusteredSurrogate, f_min: f64) -> Array1<f64> {
+    let pt = ArrayView::from_shape((1, x.len()), x).unwrap();
+    if let Ok(p) = obj_model.predict_values(&pt) {
+        if let Ok(s) = obj_model.predict_variances(&pt) {
+            let sigma = s[[0, 0]].sqrt();
+            if sigma.abs() < 1e-12 {
+                Array1::zeros(pt.len())
+            } else {
+                let pred = p[[0, 0]];
+                let diff_y = f_min - pred;
+                let arg = (f_min - pred) / sigma;
+                let y_prime = obj_model.predict_jacobian(&pt).unwrap();
+                let y_prime = y_prime.row(0);
+                let sig_2_prime = obj_model.predict_variance_jacobian(&pt).unwrap();
+
+                let sig_2_prime = sig_2_prime.row(0);
+                let sig_prime = sig_2_prime.mapv(|v| v / (2. * sigma));
+                let arg_prime = y_prime.mapv(|v| v / (-sigma))
+                    - diff_y.to_owned() * sig_prime.mapv(|v| v / (sigma * sigma));
+                let factor = sigma * (-arg / SQRT_2PI) * (-(arg * arg) / 2.).exp();
+
+                let arg1 = y_prime.mapv(|v| v * (-norm_cdf(arg)));
+                let arg2 = diff_y * norm_pdf(arg) * arg_prime.to_owned();
+                let arg3 = sig_prime.to_owned() * norm_pdf(arg);
+                let arg4 = factor * arg_prime;
+                arg1 + arg2 + arg3 + arg4
+            }
+        } else {
+            Array1::zeros(pt.len())
+        }
+    } else {
+        Array1::zeros(pt.len())
+    }
+}
+
 pub fn wb2s(x: &[f64], obj_model: &dyn ClusteredSurrogate, f_min: f64, scale: f64) -> f64 {
     let pt = ArrayView::from_shape((1, x.len()), x).unwrap();
     let ei = ei(x, obj_model, f_min);
     scale * ei - obj_model.predict_values(&pt).unwrap()[[0, 0]]
+}
+
+pub fn grad_wbs2(
+    x: &[f64],
+    obj_model: &dyn ClusteredSurrogate,
+    f_min: f64,
+    scale: f64,
+) -> Array1<f64> {
+    let pt = ArrayView::from_shape((1, x.len()), x).unwrap();
+    let grad_ei = grad_ei(x, obj_model, f_min) * scale;
+    grad_ei - obj_model.predict_jacobian(&pt).unwrap().row(0)
 }
 
 pub fn compute_wb2s_scale(
@@ -125,7 +171,10 @@ pub fn update_data(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::array;
+    use egobox_doe::SamplingMethod;
+    use egobox_moe::*;
+    use linfa::prelude::*;
+    use ndarray::{array, Array};
 
     #[test]
     fn test_is_update_ok() {
@@ -149,5 +198,44 @@ mod tests {
         );
         assert_eq!(&array![[0., 1.], [2., 3.], [3., 4.]], xdata);
         assert_eq!(&array![[3.], [4.], [6.]], ydata);
+    }
+
+    fn sphere(x: &Array2<f64>) -> Array2<f64> {
+        let s = (x * x).sum_axis(Axis(1));
+        s.insert_axis(Axis(1))
+    }
+    #[test]
+    fn test_grad_ei() {
+        let xt = egobox_doe::Lhs::new(&array![[-10., 10.], [-10., 10.]]).sample(100);
+        let yt = sphere(&xt);
+        let gp = Moe::params()
+            .regression_spec(RegressionSpec::CONSTANT)
+            .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
+            .recombination(Recombination::Hard)
+            .fit(&Dataset::new(xt, yt))
+            .expect("GP fitting");
+        let bgp = Box::new(gp) as Box<dyn ClusteredSurrogate>;
+
+        let h = 1e-5;
+        let x1 = 2.;
+        let x2 = 3.;
+        let xtest = vec![x1, x2];
+        let xtest11 = vec![x1 + h, x2];
+        let xtest12 = vec![x1 - h, x2];
+        let xtest21 = vec![x1, x2 + h];
+        let xtest22 = vec![x1, x2 - h];
+        let fdiff1 = (grad_ei(&xtest11, bgp.as_ref(), 0.1) - grad_ei(&xtest12, bgp.as_ref(), 0.1))
+            / (2. * h);
+        let fdiff2 = (grad_ei(&xtest21, bgp.as_ref(), 0.1) - grad_ei(&xtest22, bgp.as_ref(), 0.1))
+            / (2. * h);
+        println!("fdiff({:?}) = [{}, {}]", xtest, fdiff1, fdiff2);
+
+        let basetest = Array::from_vec(xtest.clone());
+        let arrtest = basetest.broadcast((2, xtest.len())).unwrap();
+        println!(
+            "GP predict derivatives({:?}) = {:?}",
+            xtest,
+            bgp.predict_jacobian(&arrtest.view()).unwrap()
+        )
     }
 }

--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -209,20 +209,14 @@ impl<F: Float> GaussianProcess<F, ConstantMean, SquaredExponentialCorr> {
         kx: usize,
     ) -> Array2<F> {
         let corr = self._compute_correlation(x);
-        println!("R={:?}", corr);
-
         let x = (x - &self.xtrain.mean) / &self.xtrain.std;
         let df = Array2::<F>::zeros((1, x.nrows()));
         let beta = &self.inner_params.beta;
-        println!("beta={:?}", beta);
         let gamma = &self.inner_params.gamma;
-        println!("gamma={:?}", gamma);
         let df_dx = &df.t().dot(beta);
 
         let nr = x.nrows();
         let nc = self.xtrain.data.nrows();
-        println!("x={:?}", x);
-        println!("self.xtrain.data={:?}", self.xtrain.data);
         let d_dx = &x
             .column(kx)
             .to_owned()
@@ -240,11 +234,9 @@ impl<F: Float> GaussianProcess<F, ConstantMean, SquaredExponentialCorr> {
                 .broadcast((nr, nc))
                 .unwrap()
                 .to_owned();
-        println!("d_dx={:?}", d_dx);
 
         // Get pairwise componentwise L1-distances to the input training set
         let theta = &self.theta.to_owned().insert_axis(Axis(0));
-        println!("theta={:?}", theta);
 
         let dcorr = theta.mapv(|v| F::cast(2) * v) * (d_dx * corr);
         (df_dx - dcorr.dot(gamma)) * &self.ytrain.std / &self.xtrain.std

--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -747,12 +747,12 @@ mod tests {
         };
     }
 
-    test_gp!(Constant, SquaredExponential, 1.66);
+    test_gp!(Constant, SquaredExponential, 1.67);
     test_gp!(Constant, AbsoluteExponential, 22.35);
     test_gp!(Constant, Matern32, 21.68);
     test_gp!(Constant, Matern52, 21.68);
 
-    test_gp!(Linear, SquaredExponential, 1.55);
+    test_gp!(Linear, SquaredExponential, 1.56);
     test_gp!(Linear, AbsoluteExponential, 21.68);
     test_gp!(Linear, Matern32, 21.68);
     test_gp!(Linear, Matern52, 21.68);

--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -253,10 +253,7 @@ impl<F: Float, Mean: RegressionModel<F>, Corr: CorrelationModel<F>> GaussianProc
 
     /// Predict derivatives of the output prediction variance
     /// wrt the kx th components at point one input.
-    pub fn predict_variance_derivatives(
-        &self,
-        x: &ArrayBase<impl Data<Elem = F>, Ix2>,
-    ) -> Array2<F> {
+    pub fn predict_variance_jacobian(&self, x: &ArrayBase<impl Data<Elem = F>, Ix2>) -> Array2<F> {
         // Initialization
         let xnorm = (x - &self.xtrain.mean) / &self.xtrain.std;
         let theta = &self.theta;
@@ -1013,7 +1010,7 @@ mod tests {
         .expect("GP fitting");
 
         let x = array![[0.5]];
-        let dvar = gp.predict_variance_derivatives(&x);
+        let dvar = gp.predict_variance_jacobian(&x);
         println!("dvar={}", dvar)
     }
 }

--- a/gp/src/utils.rs
+++ b/gp/src/utils.rs
@@ -1,5 +1,5 @@
 use linfa::Float;
-use ndarray::{s, Array1, Array2, ArrayBase, Axis, Data, Ix2};
+use ndarray::{s, Array1, Array2, Array3, ArrayBase, Axis, Data, Ix2};
 #[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 
@@ -107,10 +107,53 @@ impl<F: Float> DistanceMatrix<F> {
     }
 }
 
+fn differences<F: Float>(
+    x: &ArrayBase<impl Data<Elem = F>, Ix2>,
+    y: &ArrayBase<impl Data<Elem = F>, Ix2>,
+) -> Array3<F> {
+    let x = x.to_owned().insert_axis(Axis(1));
+    let y = y.to_owned().insert_axis(Axis(0));
+    let d = x - y;
+    d
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_abs_diff_eq;
     use ndarray::array;
+
+    #[test]
+    fn test_differences() {
+        let x = array![[-0.9486833], [-0.82219219]];
+        let y = array![
+            [-1.26491106],
+            [-0.63245553],
+            [0.],
+            [0.63245553],
+            [1.26491106]
+        ];
+        assert_abs_diff_eq!(
+            &array![
+                [
+                    [0.31622777],
+                    [-0.31622777],
+                    [-0.9486833],
+                    [-1.58113883],
+                    [-2.21359436]
+                ],
+                [
+                    [0.44271887],
+                    [-0.18973666],
+                    [-0.82219219],
+                    [-1.45464772],
+                    [-2.08710326]
+                ]
+            ],
+            &differences(&x, &y),
+            epsilon = 1e-6
+        )
+    }
 
     #[test]
     fn test_normalized_matrix() {

--- a/moe/src/gaussian_mixture.rs
+++ b/moe/src/gaussian_mixture.rs
@@ -253,7 +253,7 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<usize
         let (_, log_resp) = self.estimate_log_prob_resp(observations);
         *targets = log_resp
             .mapv(F::exp)
-            .map_axis(Axis(1), |row| row.argmax().unwrap());
+            .map_axis(Axis(1), |row| row.argmax().unwrap_or(0));
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {

--- a/moe/src/surrogates.rs
+++ b/moe/src/surrogates.rs
@@ -31,11 +31,12 @@ pub trait Surrogate: std::fmt::Display + Send {
     fn predict_values(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
     /// Predict variance values at n points given as (n, xdim) matrix.
     fn predict_variances(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
-    /// Predict derivatives at n points return (n, xdim) matrix
+    /// Predict derivatives at n points and return (n, xdim) matrix
     /// where each column is the partial derivatives wrt the ith component
     fn predict_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
-    /// Predict derivatives at n points given as (n, xdim) matrix wrt kx_th component
-    // fn predict_derivatives(&self, x: &ArrayView2<f64>, kx: usize) -> Result<Array2<f64>>;
+    /// Predict derivatives of the variance at n points and return (n, xdim) matrix
+    /// where each column is the partial derivatives wrt the ith component
+    fn predict_variance_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
     /// Save model in given file.
     #[cfg(feature = "persistent")]
     fn save(&self, path: &str) -> Result<()>;
@@ -103,6 +104,9 @@ macro_rules! declare_surrogate {
                 }
                 fn predict_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
                     Ok(self.0.predict_jacobian(x))
+                }
+                fn predict_variance_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
+                    Ok(self.0.predict_variance_jacobian(x))
                 }
 
                 #[cfg(feature = "persistent")]

--- a/moe/src/surrogates.rs
+++ b/moe/src/surrogates.rs
@@ -31,6 +31,11 @@ pub trait Surrogate: std::fmt::Display + Send {
     fn predict_values(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
     /// Predict variance values at n points given as (n, xdim) matrix.
     fn predict_variances(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
+    /// Predict derivatives at n points return (n, xdim) matrix
+    /// where each column is the partial derivatives wrt the ith component
+    fn predict_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>>;
+    /// Predict derivatives at n points given as (n, xdim) matrix wrt kx_th component
+    // fn predict_derivatives(&self, x: &ArrayView2<f64>, kx: usize) -> Result<Array2<f64>>;
     /// Save model in given file.
     #[cfg(feature = "persistent")]
     fn save(&self, path: &str) -> Result<()>;
@@ -95,6 +100,9 @@ macro_rules! declare_surrogate {
                 }
                 fn predict_variances(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
                     Ok(self.0.predict_variances(x)?)
+                }
+                fn predict_jacobian(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
+                    Ok(self.0.predict_jacobian(x))
                 }
 
                 #[cfg(feature = "persistent")]


### PR DESCRIPTION
This PR implements analytic derivatives for `GaussianProcess<Constant, SquaredExponential>` and now Egor default to using Kriging only (other surrogates can be used by setting `regr_spec` and `corr_spec` options).
