### PR TITLE
Bump 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2018"
 description = "A toolbox for efficient global optimization"
@@ -25,10 +25,10 @@ persistent-ego = ["egobox-ego/persistent"]
 blas = ["ndarray/blas", "egobox-gp/blas", "egobox-moe/blas", "egobox-ego/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.5.0", path="./doe" }
-egobox-gp = { version = "0.5.0", path="./gp" }
-egobox-moe = { version = "0.5.0", path="./moe", features=["persistent"] }
-egobox-ego = { version = "0.5.0", path="./ego", features=["persistent"] }
+egobox-doe = { version = "0.6.0", path="./doe" }
+egobox-gp = { version = "0.6.0", path="./gp" }
+egobox-moe = { version = "0.6.0", path="./moe", features=["persistent"] }
+egobox-ego = { version = "0.6.0", path="./ego", features=["persistent"] }
 
 linfa = { version = "0.6.0", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Depending on the sub-packages you want to use, you have to add following declara
 
 ```
 [dependencies]
-egobox-doe = { version = "0.5.0" }
-egobox-gp  = { version = "0.5.0" }
-egobox-moe = { version = "0.5.0" }
-egobox-ego = { version = "0.5.0" }
+egobox-doe = { version = "0.6.0" }
+egobox-gp  = { version = "0.6.0" }
+egobox-moe = { version = "0.6.0" }
+egobox-ego = { version = "0.6.0" }
 ```
 
 ### Features
@@ -74,7 +74,7 @@ Otherwise, you can choose an external BLAS/LAPACK backend available through the 
 Thus, for instance, to use `gp` with the Intel MKL BLAS/LAPACK backend, you could specify in your `Cargo.toml` the following features:
 ```
 [dependencies]
-egobox-gp = { version = "0.5.0", features = ["blas", "linfa/intel-mkl-static"] }
+egobox-gp = { version = "0.6.0", features = ["blas", "linfa/intel-mkl-static"] }
 ```
 or you could run the `gp` example as follows:
 ``` bash

--- a/doe/Cargo.toml
+++ b/doe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-doe"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2018"
 description = "A library for design of experiments"

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-ego"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2018"
 description = "A library for efficient global optimization"
@@ -16,9 +16,9 @@ persistent = ["serde", "typetag", "egobox-moe/persistent", "serde_json"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.5.0", path="../doe" }
-egobox-gp = { version = "0.5.0", path="../gp" }
-egobox-moe = { version = "0.5.0", path="../moe" }
+egobox-doe = { version = "0.6.0", path="../doe" }
+egobox-gp = { version = "0.6.0", path="../gp" }
+egobox-moe = { version = "0.6.0", path="../moe" }
 
 linfa = { version = "0.6.0", default-features = false }
 linfa-pls = { version = "0.6.0", default-features = false }

--- a/gp/Cargo.toml
+++ b/gp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-gp"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2018"
 description = "A library for gaussian process modeling"
@@ -16,7 +16,7 @@ serializable = ["serde", "linfa/serde"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.5.0", path="../doe" }
+egobox-doe = { version = "0.6.0", path="../doe" }
 
 linfa = { version = "0.6.0", default-features = false }
 linfa-pls = { version = "0.6.0", default-features = false }

--- a/moe/Cargo.toml
+++ b/moe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-moe"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2018"
 description = "A library for mixture of expert gaussian processes"
@@ -16,8 +16,8 @@ persistent = ["serde", "typetag", "egobox-gp/serializable", "serde_json"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-clustering/blas", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.5.0", path = "../doe" }
-egobox-gp = { version = "0.5.0", path = "../gp" }
+egobox-doe = { version = "0.6.0", path = "../doe" }
+egobox-gp = { version = "0.6.0", path = "../gp" }
 
 linfa = { version = "0.6.0", default-features = false }
 linfa-clustering = { version = "0.6.0", default-features = false }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = ["maturin>=0.12,<0.13", "poetry_core>=1.0.0"]
 
 [tool.poetry]
 name = "egobox"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python binding for egobox EGO optimizer written in Rust"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 


### PR DESCRIPTION
- [x] `gp`: Kriging derivatives predictions are implemented (#44, #45), derivatives for Gp with linear regression are implemented (#47)
- [x] `moe`: as above derivatives for smooth and hard predictions are implemented  (#46)
- [x] `ego`: when available derivatives are used to optimize the infill criterion with slsqp (#44)  
- [x] `egobox` py binding:  add wrapping for Mixture of Experts surrogate (#31)
