### PR TITLE
Forbid predict derivatives with integer variables

### DIFF
--- a/ego/src/errors.rs
+++ b/ego/src/errors.rs
@@ -34,6 +34,9 @@ pub enum EgoError {
     /// When a linfa error occurs
     #[error(transparent)]
     LinfaError(#[from] linfa::error::Error),
+    /// When trying to use derivatives with integer variables
+    #[error("Can not use derivatives with integer variables")]
+    ForbiddenDerivativesError,
 }
 
 impl From<FailState> for EgoError {

--- a/moe/src/errors.rs
+++ b/moe/src/errors.rs
@@ -34,7 +34,7 @@ pub enum MoeError {
     /// When error during loading
     #[error("Load error: {0}")]
     LoadError(String),
-    /// When error during loading
+    /// When bad value encountered
     #[error("InvalidValue error: {0}")]
     InvalidValueError(String),
     /// When a linfa error occurs


### PR DESCRIPTION
Return "InvalidValueError" when using `predict_derivatives` or `predict_variances_derivatives` with an mixed-integer input variable type.