### PR TITLE
Variance derivatives and correlation Models with PLS

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -794,7 +794,7 @@ impl<'a, O: GroupFunc, R: Rng + SeedableRng + Clone> Egor<'a, O, R> {
 
     /// True whether surrogate gradient computation implemented
     fn is_grad_impl_available(&self) -> bool {
-        self.correlation_spec == CorrelationSpec::SQUAREDEXPONENTIAL
+        true
     }
 
     fn find_best_point(

--- a/gp/src/correlation_models.rs
+++ b/gp/src/correlation_models.rs
@@ -571,7 +571,7 @@ mod tests {
                     let weights = array![[1., 0.], [0., 1.]];
 
                     let corr = [< $corr Corr >]::default();
-                    let jac = corr.jac(&xnorm, &xtrain.data, &theta, &weights);
+                    let jac = corr.jac(&xnorm, &xtrain.data, &theta, &weights) / &xtrain.std;
 
                     let xa: f64 = x[0];
                     let xb: f64 = x[1];
@@ -592,9 +592,9 @@ mod tests {
                             let d = differences(&xnorm, &xtrain.data);
                             rxxi.assign(&(corr.apply( &d, &theta, &weights).column(0)));
                         });
-                    let fdiffa = (rxx.column(1).to_owned() - rxx.column(2)).mapv(|v| v * xtrain.std[0] / (2. * e));
+                    let fdiffa = (rxx.column(1).to_owned() - rxx.column(2)).mapv(|v| v / (2. * e));
                     assert_abs_diff_eq!(fdiffa, jac.column(0), epsilon=1e-6);
-                    let fdiffb = (rxx.column(3).to_owned() - rxx.column(4)).mapv(|v| v * xtrain.std[1] / (2. * e));
+                    let fdiffb = (rxx.column(3).to_owned() - rxx.column(4)).mapv(|v| v / (2. * e));
                     assert_abs_diff_eq!(fdiffb, jac.column(1), epsilon=1e-6);
                 }
             }

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -581,9 +581,7 @@ impl Moe {
         x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Result<Array2<f64>> {
         let probas = self.gmx.predict_probas(x);
-        println!("probas={}", probas);
         let probas_drv = self.gmx.predict_probas_derivatives(x);
-        println!("der_probas={}", probas_drv);
 
         let mut drv = Array2::<f64>::zeros((x.nrows(), x.ncols()));
 


### PR DESCRIPTION
This PR makes some progress in variance derivatives computation used in analytic expression of `Egor` infill criteria :
* Add method `predict_jacobian` to predict predict derivatives of GP at a point x (x1,.. xn)
* Fix correlation models computation when using PLS.
* 
Variance derivatives implementation needs further validation though