### PR TITLE
Make Egor serializable

### DIFF
--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -10,9 +10,10 @@ keywords = ["machine-learning", "bayesian", "optimization"]
 categories = ["algorithms", "mathematics", "science"]
 
 [features]
-default = []
+default = ["serializable"]
 
-persistent = ["serde", "typetag", "egobox-moe/persistent", "serde_json"]
+persistent = ["serializable", "serde_json"]
+serializable = ["serde", "typetag", "egobox-moe/serializable"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "mathematics", "science"]
 default = ["serializable"]
 
 persistent = ["serializable", "serde_json"]
-serializable = ["serde", "typetag", "egobox-moe/serializable"]
+serializable = ["serde", "serde/rc", "typetag", "egobox-moe/serializable", "rand_xoshiro/serde1"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
@@ -33,7 +33,7 @@ ndarray-npy = "0.8"
 
 nlopt = "0.6.0"
 rand_xoshiro = "0.6"
-libm = "0.1.1"
+libm = "0.2.6"
 finitediff = { version="0.1", features = ["ndarray"] }
 # sort-axis
 rawpointer = { version = "0.2" }

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -116,6 +116,9 @@ use rand_xoshiro::Xoshiro256Plus;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 const DOE_INITIAL_FILE: &str = "egor_initial_doe.npy";
 const DOE_FILE: &str = "egor_doe.npy";
 
@@ -210,6 +213,7 @@ impl<O: GroupFunc> EgorBuilder<O> {
 }
 
 /// EGO optimization parameterization
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct Egor<O: GroupFunc, SB: SurrogateBuilder> {
     /// Number of function evaluations allocated to find the optimum (aka evaluation budget)
     /// Note 1: if the initial doe has to be evaluated, doe size is taken into account in the avaluation budget.

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -3,7 +3,7 @@ use egobox_moe::{ClusteredSurrogate, Clustering};
 use egobox_moe::{CorrelationSpec, RegressionSpec};
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 
 /// Optimization result
@@ -17,6 +17,7 @@ pub struct OptimResult<F: Float> {
 
 /// Infill criterion used to select next promising point
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub enum InfillStrategy {
     /// Expected Improvement
     EI,
@@ -28,6 +29,7 @@ pub enum InfillStrategy {
 
 /// Optimizer used to optimize the infill criteria
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub enum InfillOptimizer {
     /// SLSQP optimizer (gradient from finite differences)
     Slsqp,
@@ -39,6 +41,7 @@ pub enum InfillOptimizer {
 /// to benefit from parallel evaluation of the objective function
 /// (The Multi-points Expected Improvement (q-EI) Criterion)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub enum QEiStrategy {
     /// Take the mean of the kriging predictor for q points
     KrigingBeliever,
@@ -52,6 +55,7 @@ pub enum QEiStrategy {
 
 /// A structure to specify an approximative value
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct ApproxValue {
     /// Nominal value
     pub value: f64,
@@ -114,15 +118,6 @@ pub trait SurrogateBuilder: Clone {
         yt: &ArrayView2<f64>,
         clustering: &Clustering,
     ) -> Result<Box<dyn ClusteredSurrogate>>;
-}
-
-/// An interface for preprocessing continuous input init_values
-///
-/// Special use for [crate::MixintEgor] optimiseur where preprocessing consists in
-/// casting continuous values to discrete ones. See [crate::MixintPreProcessor]
-pub trait PreProcessor {
-    /// Execute the pre processing on given `x` values
-    fn run(&self, x: &Array2<f64>) -> Array2<f64>;
 }
 
 /// Data used by internal infill criteria to be optimized using NlOpt

--- a/moe/Cargo.toml
+++ b/moe/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["algorithms", "mathematics", "science"]
 [features]
 default = []
 
-persistent = ["serde", "typetag", "egobox-gp/serializable", "serde_json"]
+persistent = ["serializable", "serde_json"]
+serializable = ["serde", "typetag", "egobox-gp/serializable"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-clustering/blas", "linfa-pls/blas"]
 
 [dependencies]

--- a/moe/src/algorithm.rs
+++ b/moe/src/algorithm.rs
@@ -30,11 +30,11 @@ use ndarray_rand::rand::{Rng, SeedableRng};
 use ndarray_stats::QuantileExt;
 use rand_xoshiro::Xoshiro256Plus;
 
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use std::fs;
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use std::io::Write;
 
 macro_rules! check_allowed {
@@ -355,7 +355,7 @@ fn predict_values_smooth(
 }
 
 /// Mixture of gaussian process experts
-#[cfg_attr(feature = "persistent", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct Moe {
     /// The mode of recombination to get the output prediction from experts prediction
     recombination: Recombination<f64>,
@@ -404,7 +404,7 @@ impl Clustered for Moe {
     }
 }
 
-#[cfg_attr(feature = "persistent", typetag::serde)]
+#[cfg_attr(feature = "serializable", typetag::serde)]
 impl Surrogate for Moe {
     fn predict_values(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
         match self.recombination {

--- a/moe/src/errors.rs
+++ b/moe/src/errors.rs
@@ -25,7 +25,7 @@ pub enum MoeError {
     #[error("Clustering error: {0}")]
     ClusteringError(String),
     /// When error during saving
-    #[cfg(feature = "persistent")]
+    #[cfg(feature = "serializable")]
     #[error("Save error: {0}")]
     SaveError(#[from] serde_json::Error),
     /// When error during loading

--- a/moe/src/gaussian_mixture.rs
+++ b/moe/src/gaussian_mixture.rs
@@ -13,7 +13,7 @@ use ndarray::{s, Array, Array1, Array2, Array3, ArrayBase, Axis, Data, Ix1, Ix2,
 use ndarray_linalg::{cholesky::*, triangular::*};
 use ndarray_stats::QuantileExt;
 
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 
 /// Gaussian mixture is a set of n weigthed multivariate normal distributions of dimension nx
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// Note: distribution means are handle in a (n, nx) matrix whie covariances
 /// are handled in a (n, nx, nx) ndarray
 
-#[cfg_attr(feature = "persistent", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct GaussianMixture<F: Float> {
     /// weights vector (n,) of each cluster

--- a/moe/src/lib.rs
+++ b/moe/src/lib.rs
@@ -29,10 +29,14 @@
 //!  
 //! # Features
 //!
+//! ## serializable
+//!
+//! The `serializable` feature enables serialization based on [serde crate](https://serde.rs/).
+//!
 //! ## persistent
 //!
 //! The `persistent` feature enables `save()`/`load()` methods for a MoE model
-//! to/from a json file using the [serde crate](https://serde.rs/).
+//! to/from a json file using the [serde and serde_json crates](https://serde.rs/).
 //!
 //! # Example
 //!

--- a/moe/src/parameters.rs
+++ b/moe/src/parameters.rs
@@ -14,12 +14,12 @@ use ndarray_rand::rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256Plus;
 use std::fmt::Display;
 
-#[cfg(feature = "persistent")]
+#[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
 
 /// Enumeration of recombination modes handled by the mixture
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "persistent", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub enum Recombination<F: Float> {
     /// prediction is taken from the expert with highest responsability
     /// resulting in a model with discontinuities

--- a/moe/src/parameters.rs
+++ b/moe/src/parameters.rs
@@ -50,6 +50,7 @@ bitflags! {
     /// ```
     ///
     /// See [bitflags::bitflags]
+    #[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
     pub struct RegressionSpec: u8 {
         /// Constant regression
         const CONSTANT = 0x01;
@@ -73,6 +74,7 @@ bitflags! {
     /// ```
     ///
     /// See [bitflags::bitflags]
+    #[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
     pub struct CorrelationSpec: u8 {
         /// Squared exponential correlation model
         const SQUAREDEXPONENTIAL = 0x01;


### PR DESCRIPTION
Following #65 , `Egor` is made serializable with `serde` when `serializable` feature is enabled.