### PR TITLE
Parallel multistart optimizations

### DIFF
--- a/doe/src/lhs.rs
+++ b/doe/src/lhs.rs
@@ -116,12 +116,7 @@ impl<F: Float, R: Rng + Clone> Lhs<F, R> {
         }
     }
 
-    fn _maximin_ese(
-        &self,
-        lhs: &Array2<F>,
-        outer_loop: usize,
-        inner_loop: usize
-    ) -> Array2<F> {
+    fn _maximin_ese(&self, lhs: &Array2<F>, outer_loop: usize, inner_loop: usize) -> Array2<F> {
         // hard-coded params
         let j_range = 20;
         let p = F::cast(10.);
@@ -298,7 +293,7 @@ impl<F: Float, R: Rng + Clone> Lhs<F, R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::{assert_abs_diff_ne, assert_abs_diff_eq};
+    use approx::{assert_abs_diff_eq, assert_abs_diff_ne};
     use ndarray::{arr2, array};
     use std::time::Instant;
 
@@ -392,8 +387,7 @@ mod tests {
     #[test]
     fn test_no_duplicate() {
         let xlimits = arr2(&[[5., 10.], [0., 1.]]);
-        let lhs = Lhs::new(&xlimits)
-            .with_rng(Xoshiro256Plus::seed_from_u64(42));
+        let lhs = Lhs::new(&xlimits).with_rng(Xoshiro256Plus::seed_from_u64(42));
 
         let sample1 = lhs.sample(5);
         let sample2 = lhs.sample(5);

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -240,15 +240,17 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let dim = args.dim;
+    let n_doe = 3 * dim;
     let cstr_tol = 1e-4;
     let mut xlimits = Array2::zeros((dim, 2));
     xlimits.column_mut(1).assign(&Array1::ones(dim));
+    
     let res = EgorBuilder::optimize(mopta_func(dim))
         .min_within(&xlimits)
         .n_cstr(68)
         .cstr_tol(cstr_tol)
-        .n_clusters(Some(0))
-        .n_doe(250)
+        .n_clusters(Some(1))
+        .n_doe(n_doe)
         .n_eval(100)
         .regression_spec(RegressionSpec::CONSTANT)
         .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -240,7 +240,7 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let dim = args.dim;
-    let n_doe = 3 * dim;
+    let n_doe = 2 * dim;
     let cstr_tol = 1e-4;
     let mut xlimits = Array2::zeros((dim, 2));
     xlimits.column_mut(1).assign(&Array1::ones(dim));

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -244,7 +244,7 @@ fn main() -> anyhow::Result<()> {
     let cstr_tol = 1e-4;
     let mut xlimits = Array2::zeros((dim, 2));
     xlimits.column_mut(1).assign(&Array1::ones(dim));
-    
+
     let res = EgorBuilder::optimize(mopta_func(dim))
         .min_within(&xlimits)
         .n_cstr(68)

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -881,8 +881,12 @@ where
         f_min: f64,
     ) -> (f64, Array1<f64>, f64) {
         let scaling_points = sampling.sample(100 * self.xlimits.nrows());
-        let scale_infill_obj = self.compute_infill_obj_scale(&scaling_points.view(), obj_model, f_min);
-        info!("Infill criterion scaling is updated to {}", scale_infill_obj);
+        let scale_infill_obj =
+            self.compute_infill_obj_scale(&scaling_points.view(), obj_model, f_min);
+        info!(
+            "Infill criterion scaling is updated to {}",
+            scale_infill_obj
+        );
         let scale_cstr = if cstr_models.is_empty() {
             Array1::zeros((0,))
         } else {
@@ -1133,15 +1137,16 @@ where
         }
     }
 
-    fn compute_infill_obj_scale(&self, x: &ArrayView2<f64>, obj_model: &dyn ClusteredSurrogate, f_min: f64) -> f64 {
+    fn compute_infill_obj_scale(
+        &self,
+        x: &ArrayView2<f64>,
+        obj_model: &dyn ClusteredSurrogate,
+        f_min: f64,
+    ) -> f64 {
         let mut crit_vals = Array1::zeros(x.nrows());
         Zip::from(&mut crit_vals).and(x.rows()).for_each(|c, x| {
             let val = self.eval_infill_obj(&x.to_vec(), obj_model, f_min, 1.0, 1.0);
-            *c = if val.is_infinite() {
-                1.0
-            } else {
-                val.abs()
-            }; 
+            *c = if val.is_infinite() { 1.0 } else { val.abs() };
         });
         let scale = *crit_vals.max().unwrap_or(&1.0);
         if scale < f64::EPSILON {

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -1008,7 +1008,8 @@ where
                 success = true;
             } else {
                 let dim = x_data.ncols();
-                let optims: Vec<(f64, Vec<f64>)> = (0..self.n_start)
+
+                let res = (0..self.n_start)
                     .into_iter()
                     .map(|i| {
                         let obj = |x: &[f64],
@@ -1138,9 +1139,8 @@ where
                             }
                         }
                     })
-                    .collect();
+                    .reduce(|a, b| if b.0 < a.0 { b } else { a });
 
-                let res = optims.iter().reduce(|a, b| if b.0 > a.0 { b } else { a });
                 if let Some(res) = res {
                     if res.0.is_nan() || res.0.is_infinite() {
                         success = false;

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -614,7 +614,6 @@ where
                 None
             };
 
-            info!("Find optimum location best candidates...");
             let (x_dat, y_dat) = self.next_points(
                 init,
                 recluster,
@@ -715,11 +714,10 @@ where
     }
 
     fn terminate(&mut self, state: &EgorState<f64>) -> TerminationStatus {
-        debug!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> TERMINATE");
+        debug!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> end iteration");
         debug!("Current Cost {:?}", state.get_cost());
         debug!("Best cost {:?}", state.get_best_cost());
-        debug!("Target cost {:?}", state.get_target_cost());
-        // XXX: Should check target cost
+        // XXX: Should check target cost taking into account constraints
         // if state.get_best_cost() <= state.get_target_cost() {
         //     info!("Target optimum : {}", self.target);
         //     info!("Expected optimum reached!");
@@ -805,7 +803,7 @@ where
                 )
             };
 
-            info!("Train surrogates with {} points...", x_dat.nrows());
+            info!("Train surrogates with {} points...", xt.nrows());
             let obj_model = self.make_clustered_surrogate(
                 &xt,
                 &yt.slice(s![.., 0..1]).to_owned(),
@@ -995,6 +993,7 @@ where
             })
             .collect();
 
+        info!("Optimize infill criterion...");
         while !success && n_optim <= n_max_optim {
             let x_start = sampling.sample(self.n_start);
 
@@ -1090,6 +1089,9 @@ where
                 success = true;
             }
             n_optim += 1;
+        }
+        if best_x.is_some() {
+            debug!("... infill criterion optimum found");
         }
         best_x.ok_or_else(|| EgoError::EgoError(String::from("Can not find best point")))
     }

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -1019,7 +1019,7 @@ where
                                 scale_wb2,
                                 scale_cstr: scale_cstr.to_owned(),
                             },
-                            1e-6 / scale_cstr[i],
+                            self.cstr_tol / scale_cstr[i],
                         )
                         .unwrap();
                 });

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -1,4 +1,4 @@
-use crate::types::{CstrFn, ObjData};
+use crate::types::ObjData;
 use egobox_doe::{Lhs, LhsKind, SamplingMethod};
 use ndarray::{Array1, Array2, Axis, Zip};
 use ndarray_rand::rand::{Rng, SeedableRng};

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -1,4 +1,4 @@
-use crate::types::ObjData;
+use crate::types::{CstrFn, ObjData};
 use egobox_doe::{Lhs, LhsKind, SamplingMethod};
 use ndarray::{Array1, Array2, Axis, Zip};
 use ndarray_rand::rand::{Rng, SeedableRng};
@@ -18,7 +18,7 @@ pub(crate) struct LhsOptimizer<'a, R: Rng + Clone> {
     n_points: usize,
     cstr_tol: f64,
     obj: &'a dyn ObjFn<ObjData<f64>>,
-    cstrs: Vec<&'a dyn ObjFn<ObjData<f64>>>,
+    cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
     obj_data: ObjData<f64>,
     rng: R,
 }
@@ -27,7 +27,7 @@ impl<'a> LhsOptimizer<'a, Xoshiro256Plus> {
     pub fn new(
         xlimits: &Array2<f64>,
         obj: &'a dyn ObjFn<ObjData<f64>>,
-        cstrs: Vec<&'a dyn ObjFn<ObjData<f64>>>,
+        cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
         obj_data: &ObjData<f64>,
     ) -> LhsOptimizer<'a, Xoshiro256Plus> {
         Self::new_with_rng(
@@ -44,7 +44,7 @@ impl<'a, R: Rng + Clone> LhsOptimizer<'a, R> {
     pub fn new_with_rng(
         xlimits: &Array2<f64>,
         obj: &'a dyn ObjFn<ObjData<f64>>,
-        cstrs: Vec<&'a dyn ObjFn<ObjData<f64>>>,
+        cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
         obj_data: &ObjData<f64>,
         rng: R,
     ) -> LhsOptimizer<'a, R> {

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -175,7 +175,7 @@ mod tests {
 
         let xlimits = array![[-1., 1.]];
         let obj_data = ObjData {
-            scale_obj: 1.,
+            scale_infill_obj: 1.,
             scale_cstr: array![],
             scale_wb2: 1.,
         };

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -3,6 +3,7 @@ use egobox_doe::{Lhs, LhsKind, SamplingMethod};
 use ndarray::{Array1, Array2, Axis, Zip};
 use ndarray_rand::rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256Plus;
+use rayon::prelude::*;
 
 #[cfg(not(feature = "blas"))]
 use linfa_linalg::norm::*;
@@ -12,12 +13,12 @@ use ndarray_linalg::Norm;
 use ndarray_stats::QuantileExt;
 use nlopt::ObjFn;
 
-pub(crate) struct LhsOptimizer<'a, R: Rng + Clone> {
+pub(crate) struct LhsOptimizer<'a, R: Rng + Clone + Sync + Send> {
     xlimits: Array2<f64>,
     n_start: usize,
     n_points: usize,
     cstr_tol: f64,
-    obj: &'a dyn ObjFn<ObjData<f64>>,
+    obj: &'a (dyn ObjFn<ObjData<f64>> + Sync),
     cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
     obj_data: ObjData<f64>,
     rng: R,
@@ -26,7 +27,7 @@ pub(crate) struct LhsOptimizer<'a, R: Rng + Clone> {
 impl<'a> LhsOptimizer<'a, Xoshiro256Plus> {
     pub fn new(
         xlimits: &Array2<f64>,
-        obj: &'a dyn ObjFn<ObjData<f64>>,
+        obj: &'a (dyn ObjFn<ObjData<f64>> + Sync),
         cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
         obj_data: &ObjData<f64>,
     ) -> LhsOptimizer<'a, Xoshiro256Plus> {
@@ -40,10 +41,10 @@ impl<'a> LhsOptimizer<'a, Xoshiro256Plus> {
     }
 }
 
-impl<'a, R: Rng + Clone> LhsOptimizer<'a, R> {
+impl<'a, R: Rng + Clone + Sync + Send> LhsOptimizer<'a, R> {
     pub fn new_with_rng(
         xlimits: &Array2<f64>,
-        obj: &'a dyn ObjFn<ObjData<f64>>,
+        obj: &'a (dyn ObjFn<ObjData<f64>> + Sync),
         cstrs: Vec<&'a (dyn ObjFn<ObjData<f64>> + Sync)>,
         obj_data: &ObjData<f64>,
         rng: R,
@@ -60,7 +61,7 @@ impl<'a, R: Rng + Clone> LhsOptimizer<'a, R> {
         }
     }
 
-    pub fn with_rng<R2: Rng + Clone>(self, rng: R2) -> LhsOptimizer<'a, R2> {
+    pub fn with_rng<R2: Rng + Clone + Sync + Send>(self, rng: R2) -> LhsOptimizer<'a, R2> {
         LhsOptimizer {
             xlimits: self.xlimits,
             n_start: self.n_start,
@@ -74,16 +75,18 @@ impl<'a, R: Rng + Clone> LhsOptimizer<'a, R> {
     }
 
     pub fn minimize(&self) -> Array1<f64> {
-        let mut x_optim = vec![];
+        let lhs = Lhs::new(&self.xlimits)
+            .kind(LhsKind::Classic)
+            .with_rng(self.rng.clone());
 
         // Make n_start optim
-        for _ in 0..self.n_start {
-            x_optim.push(self.find_lhs_min());
-        }
+        let x_optims = (0..self.n_start).into_par_iter().map(|_| {
+            self.find_lhs_min(lhs.clone())
+        }).collect::<Vec<_>>();
 
         // Pick best
-        if x_optim.iter().any(|opt| opt.0) {
-            let values: Array1<_> = x_optim
+        if x_optims.iter().any(|opt| opt.0) {
+            let values: Array1<_> = x_optims
                 .iter()
                 .filter(|opt| opt.0)
                 .map(|opt| (opt.1.to_owned(), opt.2))
@@ -92,18 +95,15 @@ impl<'a, R: Rng + Clone> LhsOptimizer<'a, R> {
             let index_min = yvals.argmin().unwrap();
             values[index_min].0.to_owned()
         } else {
-            let l1_norms: Array1<_> = x_optim.iter().map(|opt| opt.3.norm_l1()).collect();
+            let l1_norms: Array1<_> = x_optims.iter().map(|opt| opt.3.norm_l1()).collect();
             let index_min = l1_norms.argmin().unwrap();
-            x_optim[index_min].1.to_owned()
+            x_optims[index_min].1.to_owned()
         }
     }
 
-    fn find_lhs_min(&self) -> (bool, Array1<f64>, f64, Array1<f64>) {
+    fn find_lhs_min(&self, lhs: Lhs<f64, R>) -> (bool, Array1<f64>, f64, Array1<f64>) {
         let n = self.n_points * self.xlimits.nrows();
-        let doe = Lhs::new(&self.xlimits)
-            .kind(LhsKind::Classic)
-            .with_rng(self.rng.clone())
-            .sample(n);
+        let doe = lhs.sample(n);
 
         let y: Array1<f64> = doe.map_axis(Axis(1), |x| {
             (self.obj)(&x.to_vec(), None, &mut self.obj_data.clone())

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -80,9 +80,10 @@ impl<'a, R: Rng + Clone + Sync + Send> LhsOptimizer<'a, R> {
             .with_rng(self.rng.clone());
 
         // Make n_start optim
-        let x_optims = (0..self.n_start).into_par_iter().map(|_| {
-            self.find_lhs_min(lhs.clone())
-        }).collect::<Vec<_>>();
+        let x_optims = (0..self.n_start)
+            .into_par_iter()
+            .map(|_| self.find_lhs_min(lhs.clone()))
+            .collect::<Vec<_>>();
 
         // Pick best
         if x_optims.iter().any(|opt| opt.0) {

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -135,7 +135,7 @@ pub trait SurrogateBuilder: Clone + Serialize + Sync {
 /// Data used by internal infill criteria to be optimized using NlOpt
 #[derive(Clone)]
 pub(crate) struct ObjData<F> {
-    pub scale_obj: F,
+    pub scale_infill_obj: F,
     pub scale_cstr: Array1<F>,
     pub scale_wb2: F,
 }

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -105,7 +105,7 @@ pub fn compute_wb2s_scale(
         .predict_values(&x.row(i_max).insert_axis(Axis(0)))
         .unwrap()[[0, 0]];
     let ei_max = ei_x[i_max];
-    if ei_max.abs() > 100.*f64::EPSILON {
+    if ei_max.abs() > 100. * f64::EPSILON {
         ratio * pred_max / ei_max
     } else {
         1.

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -105,23 +105,11 @@ pub fn compute_wb2s_scale(
         .predict_values(&x.row(i_max).insert_axis(Axis(0)))
         .unwrap()[[0, 0]];
     let ei_max = ei_x[i_max];
-    if ei_max > 0. {
+    if ei_max.abs() > 100.*f64::EPSILON {
         ratio * pred_max / ei_max
     } else {
         1.
     }
-}
-
-/// Computes the scaling factor used to scale objective function value.
-pub fn compute_obj_scale(x: &ArrayView2<f64>, obj_model: &dyn ClusteredSurrogate) -> f64 {
-    let preds: Array1<f64> = obj_model
-        .predict_values(x)
-        .unwrap()
-        .into_iter()
-        .filter(|v| !v.is_infinite()) // filter out infinite values
-        .map(|v| v.abs())
-        .collect();
-    *preds.max().unwrap_or(&1.0)
 }
 
 /// Computes scaling factors used to scale constraint functions values.


### PR DESCRIPTION
This PR introduces the parallel executions of infill criterion optimizations (multistart).
It also fixes several bugs related to criterion optimization:
* `cstr_tol` is now used by infill criterion optimization
* infill criterion is now scaled with correct value
* successive samplings with same LHS are now different  