### PR TITLE
Number of evaluations rework

### DIFF
--- a/ego/examples/ackley.rs
+++ b/ego/examples/ackley.rs
@@ -18,7 +18,7 @@ fn main() {
         .regression_spec(RegressionSpec::CONSTANT)
         .correlation_spec(CorrelationSpec::ABSOLUTEEXPONENTIAL)
         .infill_strategy(InfillStrategy::WB2S)
-        .n_eval(200)
+        .n_iter(200)
         .target(5e-1)
         .run()
         .expect("Minimize failure");

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -240,7 +240,8 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let dim = args.dim;
-    let n_doe = if dim == 124 { 150 } else { dim + 1 };
+    let n_doe = 2 * dim;
+    let n_iter = 3 * dim;
     let cstr_tol = 1e-4;
 
     let mut xlimits = Array2::zeros((dim, 2));
@@ -253,7 +254,7 @@ fn main() -> anyhow::Result<()> {
         .n_clusters(Some(1))
         .n_doe(n_doe)
         .n_start(50)
-        .n_eval(350)
+        .n_iter(n_iter)
         .regression_spec(RegressionSpec::CONSTANT)
         .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
         .infill_optimizer(InfillOptimizer::Slsqp)

--- a/ego/examples/rosenbrock.rs
+++ b/ego/examples/rosenbrock.rs
@@ -20,7 +20,7 @@ fn main() {
     let xlimits = array![[-2., 2.], [-2., 2.]];
     let res = EgorBuilder::optimize(rosenbrock)
         .min_within(&xlimits)
-        .n_eval(100)
+        .n_iter(100)
         .target(1e-2)
         .run()
         .expect("Minimize failure");

--- a/ego/src/egor_state.rs
+++ b/ego/src/egor_state.rs
@@ -115,20 +115,6 @@ mod tests {
 /// Maintains the state from iteration to iteration of the [crate::EgorSolver].
 ///
 /// This struct is passed from one iteration of an algorithm to the next.
-///
-/// Keeps track of
-///
-/// * parameter vector of current and previous iteration
-/// * best parameter vector of current and previous iteration
-/// * cost function value (objective and constraint functions values) of current and previous iteration
-/// * current and previous best cost function value
-/// * target cost function value
-/// * current iteration number
-/// * iteration number where the last best parameter vector was found
-/// * maximum number of iterations that will be executed
-/// * problem function evaluation counts ()
-/// * elapsed time
-/// * termination reason (set to [`TerminationReason::NotTerminated`] if not terminated yet)
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct EgorState<F: Float> {
     /// Current parameter vector
@@ -141,6 +127,8 @@ pub struct EgorState<F: Float> {
     pub prev_best_param: Option<Array1<F>>,
 
     /// Current cost function value
+    /// The first component is the actual cost value
+    /// while the remaining ones are the constraints values
     pub cost: Option<Array1<F>>,
     /// Previous cost function value
     pub prev_cost: Option<Array1<F>>,

--- a/ego/src/lib.rs
+++ b/ego/src/lib.rs
@@ -26,7 +26,7 @@
 //! // We ask for 10 evaluations of the objective function to get the result
 //! let res = EgorBuilder::optimize(xsinx)
 //!             .min_within(&array![[0.0, 25.0]])
-//!             .n_eval(10)
+//!             .n_iter(10)
 //!             .run()
 //!             .expect("xsinx minimized");
 //! println!("Minimum found f(x) = {:?} at x = {:?}", res.x_opt, res.y_opt);
@@ -58,7 +58,7 @@
 //!     }
 //! }
 //!
-//! let n_eval = 10;
+//! let n_iter = 10;
 //! let doe = array![[0.], [7.], [25.]];
 //!
 //! // We define input as being integer
@@ -68,7 +68,7 @@
 //!     .random_seed(42)
 //!     .min_within_mixed_space(&xtypes)   // We build mixed-integer optimizer
 //!     .doe(Some(doe))          // we pass an initial doe
-//!     .n_eval(n_eval)
+//!     .n_iter(n_iter)
 //!     .infill_strategy(InfillStrategy::EI)
 //!     .run()
 //!     .expect("Egor minimization");

--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -62,7 +62,7 @@ impl<F: Float> Clone for GpInnerParams<F> {
     }
 }
 
-/// Gaussian Process
+/// Structure for trained Gaussian Process model
 #[derive(Debug)]
 #[cfg_attr(
     feature = "serializable",

--- a/gp/src/parameters.rs
+++ b/gp/src/parameters.rs
@@ -59,7 +59,7 @@ impl<F: Float, Mean: RegressionModel<F>, Corr: CorrelationModel<F>> GpValidParam
 
 #[derive(Clone, Debug)]
 /// The set of hyperparameters that can be specified for the execution of
-/// the [GMM algorithm](struct.GaussianMixtureModel.html).
+/// the [GP algorithm](struct.GaussianProcess.html).
 pub struct GpParams<F: Float, Mean: RegressionModel<F>, Corr: CorrelationModel<F>>(
     GpValidParams<F, Mean, Corr>,
 );

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -81,14 +81,14 @@ def six_humps(x):
 class TestOptimizer(unittest.TestCase):
     def test_xsinx(self):
         egor = egx.Egor(xsinx, egx.to_specs([[0.0, 25.0]]), seed=42)
-        res = egor.minimize(n_eval=20)
+        res = egor.minimize(n_iter=20)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-3)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
 
     def test_xsinx_with_reclustering(self):
         egor = egx.Egor(xsinx, egx.to_specs([[0.0, 25.0]]), seed=42, n_clusters=0)
-        res = egor.minimize(n_eval=20)
+        res = egor.minimize(n_iter=20)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-3)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
@@ -101,13 +101,13 @@ class TestOptimizer(unittest.TestCase):
         xlimits = egx.to_specs([[0.0, 25.0]])
         doe = egx.lhs(xlimits, 10)
         egor = egx.Egor(xsinx, xlimits, doe=doe, seed=42, outdir="./test_dir")
-        res = egor.minimize(n_eval=15)
+        res = egor.minimize(n_iter=15)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-3)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
 
         egor = egx.Egor(xsinx, xlimits, outdir="./test_dir", hot_start=True)
-        res = egor.minimize(n_eval=5)
+        res = egor.minimize(n_iter=5)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-2)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-2)
@@ -126,7 +126,7 @@ class TestOptimizer(unittest.TestCase):
             seed=42,
         )
         start = time.process_time()
-        res = egor.minimize(n_eval=20)
+        res = egor.minimize(n_iter=20)
         end = time.process_time()
         print(f"Optimization f={res.y_opt} at {res.x_opt} in {end-start}s")
         self.assertAlmostEqual(-5.5080, res.y_opt[0], delta=1e-2)
@@ -145,7 +145,7 @@ class TestOptimizer(unittest.TestCase):
             seed=1,
         )
         start = time.process_time()
-        res = egor.minimize(n_eval=20)
+        res = egor.minimize(n_iter=20)
         end = time.process_time()
         self.assertAlmostEqual(-5.5080, res.y_opt[0], delta=5e-1)
         print(f"Optimization f={res.y_opt} at {res.x_opt} in {end-start}s")
@@ -158,7 +158,7 @@ class TestOptimizer(unittest.TestCase):
             seed=42,
         )
         start = time.process_time()
-        res = egor.minimize(n_eval=45)
+        res = egor.minimize(n_iter=45)
         end = time.process_time()
         print(f"Optimization f={res.y_opt} at {res.x_opt} in {end-start}s")
         # 2 global optimum value =-1.0316 located at (0.089842, -0.712656) and  (-0.089842, 0.712656)

--- a/python/egobox/tests/test_mixintegor.py
+++ b/python/egobox/tests/test_mixintegor.py
@@ -19,7 +19,7 @@ class TestMixintEgx(unittest.TestCase):
         xtypes = [egx.Vspec(egx.Vtype(egx.Vtype.INT), [0.0, 25.0])]
 
         egor = egx.Egor(xsinx, xtypes, seed=42, n_doe=7)
-        res = egor.minimize(n_eval=10)
+        res = egor.minimize(n_iter=10)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=5e-3)
         self.assertAlmostEqual(19, res.x_opt[0], delta=1)

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -118,7 +118,7 @@ pub(crate) fn lhs(
 ///         Can be either InfillStrategy.EI, InfillStrategy.WB2 or InfillStrategy.WB2S.
 ///
 ///     q_points (int > 0):
-///         Number of parallel evaluations of the function under optimization.
+///         Number of points to be evaluated to allow parallel evaluation of the function under optimization.
 ///
 ///     par_infill_strategy (ParInfillStrategy enum)
 ///         Parallel infill criteria (aka qEI) to get virtual next promising points in order to allow
@@ -262,7 +262,7 @@ impl Egor {
     ///
     /// # Parameters
     ///     n_iter:
-    ///         the function evaluation budget, number of fun calls.
+    ///         the iteration budget, number of fun calls is n_doe + q_points * n_iter.
     ///
     /// # Returns
     ///     optimization result


### PR DESCRIPTION
Use more commonly used, the number of iterations instead of the number of evaluation of th function under optimization. More over this last number is not always accurate depending on the problem when `q_points` > 1.

This PR contains the following breaking changes:
*  `n_eval` is replaced by `n_iter`,
* `q_parallel` is replaced by `q_points` corresponding to the number of points to be evaluated by iteration (actually as some points may be rejected 1 < nb points <= q_points)

So finally we have    `n_doe` + `n_iter` <= `n_eval` <=  `n_doe` + `n_iter` * `q_points`