### PR TITLE
Improve option api

### DIFF
--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -270,7 +270,7 @@ fn main() -> anyhow::Result<()> {
         .regression_spec(RegressionSpec::CONSTANT)
         .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
         .infill_optimizer(InfillOptimizer::Slsqp)
-        .kpls_dim(Some(kpls_dim))
+        .kpls_dim(kpls_dim)
         .outdir(outdir)
         .hot_start(true)
         .run()

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -271,7 +271,7 @@ fn main() -> anyhow::Result<()> {
         .correlation_spec(CorrelationSpec::SQUAREDEXPONENTIAL)
         .infill_optimizer(InfillOptimizer::Slsqp)
         .kpls_dim(Some(kpls_dim))
-        .outdir(Some(outdir))
+        .outdir(outdir)
         .hot_start(true)
         .run()
         .expect("Minimize failure");

--- a/ego/examples/mopta08.rs
+++ b/ego/examples/mopta08.rs
@@ -263,7 +263,7 @@ fn main() -> anyhow::Result<()> {
         .min_within(&xlimits)
         .n_cstr(68)
         .cstr_tol(cstr_tol)
-        .n_clusters(Some(1))
+        .n_clusters(1)
         .n_start(50)
         .n_doe(n_doe)
         .n_iter(n_iter)

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -211,7 +211,7 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
     ///
     /// Either nt = nx then only x are specified and ns evals are done to get y doe values,
     /// or nt = nx + ny then x = doe(:, :nx) and y = doe(:, nx:) are specified
-    pub fn doe(mut self, doe: Option<Array2<f64>>) -> Self {
+    pub fn doe(mut self, doe: &Array2<f64>) -> Self {
         self.solver = self.solver.doe(doe);
         self
     }
@@ -372,7 +372,7 @@ mod tests {
             .regression_spec(RegressionSpec::QUADRATIC)
             .correlation_spec(CorrelationSpec::ALL)
             .n_iter(30)
-            .doe(Some(initial_doe.to_owned()))
+            .doe(&initial_doe)
             .target(-15.1)
             .outdir("target/tests")
             .run()
@@ -419,7 +419,7 @@ mod tests {
             .random_seed(42)
             .min_within(&xlimits)
             .n_iter(15)
-            .doe(Some(doe))
+            .doe(&doe)
             .outdir("target/tests")
             .run()
             .expect("Minimize failure");
@@ -481,7 +481,7 @@ mod tests {
         let res = EgorBuilder::optimize(rosenb)
             .random_seed(42)
             .min_within(&xlimits)
-            .doe(Some(doe))
+            .doe(&doe)
             .n_iter(100)
             .regression_spec(RegressionSpec::ALL)
             .correlation_spec(CorrelationSpec::ALL)
@@ -531,7 +531,7 @@ mod tests {
             .random_seed(42)
             .min_within(&xlimits)
             .n_cstr(2)
-            .doe(Some(doe))
+            .doe(&doe)
             .n_iter(20)
             .run()
             .expect("Minimize failure");
@@ -554,7 +554,7 @@ mod tests {
             .n_cstr(2)
             .q_points(2)
             .qei_strategy(QEiStrategy::KrigingBeliever)
-            .doe(Some(doe))
+            .doe(&doe)
             .target(-5.508013)
             .n_iter(30)
             .run()
@@ -584,7 +584,7 @@ mod tests {
         let res = EgorBuilder::optimize(mixsinx)
             .random_seed(42)
             .min_within_mixed_space(&xtypes)
-            .doe(Some(doe))
+            .doe(&doe)
             .n_iter(n_iter)
             .target(-15.1)
             .infill_strategy(InfillStrategy::EI)
@@ -602,7 +602,7 @@ mod tests {
         let res = EgorBuilder::optimize(mixsinx)
             .random_seed(42)
             .min_within_mixed_space(&xtypes)
-            .doe(Some(doe))
+            .doe(&doe)
             .n_iter(n_iter)
             .target(-15.1)
             .infill_strategy(InfillStrategy::EI)

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -272,7 +272,7 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
     }
 
     /// Sets a directory to write optimization history and used as search path for hot start doe
-    pub fn outdir(mut self, outdir: Option<String>) -> Self {
+    pub fn outdir(mut self, outdir: impl Into<String>) -> Self {
         self.solver = self.solver.outdir(outdir);
         self
     }
@@ -374,7 +374,7 @@ mod tests {
             .n_iter(30)
             .doe(Some(initial_doe.to_owned()))
             .target(-15.1)
-            .outdir(Some("target/tests".to_string()))
+            .outdir("target/tests")
             .run()
             .expect("Egor should minimize xsinx");
         let expected = array![-15.1];
@@ -420,7 +420,7 @@ mod tests {
             .min_within(&xlimits)
             .n_iter(15)
             .doe(Some(doe))
-            .outdir(Some("target/tests".to_string()))
+            .outdir("target/tests")
             .run()
             .expect("Minimize failure");
         let expected = array![18.9];
@@ -430,7 +430,7 @@ mod tests {
             .random_seed(42)
             .min_within(&xlimits)
             .n_iter(5)
-            .outdir(Some("target/tests".to_string()))
+            .outdir("target/tests")
             .hot_start(true)
             .run()
             .expect("Egor should minimize xsinx");

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -79,7 +79,7 @@
 //!            .n_cstr(2)
 //!            .infill_strategy(InfillStrategy::EI)
 //!            .infill_optimizer(InfillOptimizer::Cobyla)
-//!            .doe(Some(doe))
+//!            .doe(&doe)
 //!            .n_iter(40)
 //!            .target(-5.5080)
 //!            .run()

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -210,7 +210,7 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
     /// Sets an initial DOE containing ns samples
     ///
     /// Either nt = nx then only x are specified and ns evals are done to get y doe values,
-    /// or nt = nx + ny then x = doe(:, :nx) and y = doe(:, nx:) are specified
+    /// or nt = nx + ny then x = doe\[:, :nx\] and y = doe\[:, nx:\] are specified
     pub fn doe(mut self, doe: &Array2<f64>) -> Self {
         self.solver = self.solver.doe(doe);
         self

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -252,7 +252,7 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
     /// Sets the number of components to be used specifiying PLS projection is used (a.k.a KPLS method).
     ///
     /// This is used to address high-dimensional problems typically when nx > 9.
-    pub fn kpls_dim(mut self, kpls_dim: Option<usize>) -> Self {
+    pub fn kpls_dim(mut self, kpls_dim: usize) -> Self {
         self.solver = self.solver.kpls_dim(kpls_dim);
         self
     }

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -260,7 +260,7 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
     /// Sets the number of clusters used by the mixture of surrogate experts.
     ///
     /// When set to 0, the number of clusters is determined automatically
-    pub fn n_clusters(mut self, n_clusters: Option<usize>) -> Self {
+    pub fn n_clusters(mut self, n_clusters: usize) -> Self {
         self.solver = self.solver.n_clusters(n_clusters);
         self
     }
@@ -402,7 +402,7 @@ mod tests {
     fn test_xsinx_auto_clustering_egor_builder() {
         let res = EgorBuilder::optimize(xsinx)
             .min_within(&array![[0.0, 25.0]])
-            .n_clusters(Some(0))
+            .n_clusters(0)
             .n_iter(20)
             .run()
             .expect("Egor with auto clustering should minimize xsinx");

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -906,13 +906,6 @@ where
         let scale_ic = self
             .infill_criterion
             .scaling(&scaling_points.view(), obj_model, f_min);
-        // let scale_wb2 = if self.infill == InfillStrategy::WB2S {
-        //     let scale = compute_wb2s_scale(&scaling_points.view(), obj_model, f_min);
-        //     info!("WB2S scaling factor is updated to {}", scale);
-        //     scale
-        // } else {
-        //     1.
-        // };
         (scale_infill_obj, scale_cstr, scale_ic)
     }
 
@@ -1193,11 +1186,6 @@ where
         scale_ic: f64,
     ) -> f64 {
         let x_f = x.to_vec();
-        // let obj = match self.infill {
-        //     InfillStrategy::EI => -ei(&x_f, obj_model, f_min),
-        //     InfillStrategy::WB2 => -wb2s(&x_f, obj_model, f_min, 1.),
-        //     InfillStrategy::WB2S => -wb2s(&x_f, obj_model, f_min, scale_wb2),
-        // };
         let obj = -(self
             .infill_criterion
             .value(&x_f, obj_model, f_min, Some(scale_ic)));
@@ -1213,11 +1201,6 @@ where
         scale_ic: f64,
     ) -> Vec<f64> {
         let x_f = x.to_vec();
-        // let grad = match self.infill {
-        //     InfillStrategy::EI => -grad_ei(&x_f, obj_model, f_min),
-        //     InfillStrategy::WB2 => -grad_wbs2(&x_f, obj_model, f_min, 1.),
-        //     InfillStrategy::WB2S => -grad_wbs2(&x_f, obj_model, f_min, scale_wb2),
-        // };
         let grad = -(self
             .infill_criterion
             .grad(&x_f, obj_model, f_min, Some(scale_ic)));

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -417,8 +417,8 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     /// Sets the number of components to be used specifiying PLS projection is used (a.k.a KPLS method).
     ///
     /// This is used to address high-dimensional problems typically when nx > 9.
-    pub fn kpls_dim(mut self, kpls_dim: Option<usize>) -> Self {
-        self.kpls_dim = kpls_dim;
+    pub fn kpls_dim(mut self, kpls_dim: usize) -> Self {
+        self.kpls_dim = Some(kpls_dim);
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -426,8 +426,8 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     ///
     /// When set to Some(0), the number of clusters is determined automatically
     /// When set None, default to 1
-    pub fn n_clusters(mut self, n_clusters: Option<usize>) -> Self {
-        self.n_clusters = n_clusters;
+    pub fn n_clusters(mut self, n_clusters: usize) -> Self {
+        self.n_clusters = Some(n_clusters);
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -372,8 +372,8 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     ///
     /// Either nt = nx then only x are specified and ns evals are done to get y doe values,
     /// or nt = nx + ny then x = doe(:, :nx) and y = doe(:, nx:) are specified
-    pub fn doe(mut self, doe: Option<Array2<f64>>) -> Self {
-        self.doe = doe.map(|x| x.to_owned());
+    pub fn doe(mut self, doe: &Array2<f64>) -> Self {
+        self.doe = Some(doe.to_owned());
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -429,7 +429,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     }
 
     /// Removes any PLS dimension reduction usage
-    pub fn no_pls(mut self) -> Self {
+    pub fn no_kpls(mut self) -> Self {
         self.kpls_dim = None;
         self
     }
@@ -452,6 +452,11 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     /// Sets a directory to write optimization history and used as search path for hot start doe
     pub fn outdir(mut self, outdir: impl Into<String>) -> Self {
         self.outdir = Some(outdir.into());
+        self
+    }
+    /// Do not write optimization history
+    pub fn no_outdir(mut self) -> Self {
+        self.outdir = None;
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -438,8 +438,8 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
     }
 
     /// Sets a directory to write optimization history and used as search path for hot start doe
-    pub fn outdir(mut self, outdir: Option<String>) -> Self {
-        self.outdir = outdir;
+    pub fn outdir(mut self, outdir: impl Into<String>) -> Self {
+        self.outdir = Some(outdir.into());
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -89,7 +89,7 @@
 //!     .n_cstr(2)
 //!     .infill_strategy(InfillStrategy::EI)
 //!     .infill_optimizer(InfillOptimizer::Cobyla)
-//!     .doe(Some(doe))
+//!     .doe(&doe)
 //!     .target(-5.5080);
 //!
 //! let res = Executor::new(fobj, solver)

--- a/ego/src/lib.rs
+++ b/ego/src/lib.rs
@@ -67,7 +67,7 @@
 //! let res = EgorBuilder::optimize(mixsinx)
 //!     .random_seed(42)
 //!     .min_within_mixed_space(&xtypes)   // We build mixed-integer optimizer
-//!     .doe(Some(doe))          // we pass an initial doe
+//!     .doe(&doe)                         // we pass an initial doe
 //!     .n_iter(n_iter)
 //!     .infill_strategy(InfillStrategy::EI)
 //!     .run()

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -349,9 +349,11 @@ impl Egor {
             .qei_strategy(qei_strategy)
             .infill_optimizer(infill_optimizer)
             .kpls_dim(self.kpls_dim)
-            .n_clusters(self.n_clusters)
             .target(self.target)
             .hot_start(self.hot_start);
+        if let Some(n_clusters) = self.n_clusters {
+            mixintegor = mixintegor.n_clusters(n_clusters);
+        };
         if let Some(outdir) = self.outdir.as_ref().cloned() {
             mixintegor = mixintegor.outdir(outdir);
         };

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -348,9 +348,11 @@ impl Egor {
             .q_points(self.q_points)
             .qei_strategy(qei_strategy)
             .infill_optimizer(infill_optimizer)
-            .kpls_dim(self.kpls_dim)
             .target(self.target)
             .hot_start(self.hot_start);
+        if let Some(kpls_dim) = self.kpls_dim {
+            mixintegor = mixintegor.kpls_dim(kpls_dim);
+        };
         if let Some(n_clusters) = self.n_clusters {
             mixintegor = mixintegor.n_clusters(n_clusters);
         };

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -1,13 +1,13 @@
 //! `egobox`, Rust toolbox for efficient global optimization
 //!
 //! Thanks to the [PyO3 project](https://pyo3.rs), which makes Rust well suited for building Python extensions,
-//! the EGO algorithm written in Rust (aka `egor`) is binded in Python. You can install the Python package using:
+//! the EGO algorithm written in Rust (aka `Egor`) is binded in Python. You can install the Python package using:
 //!
 //! ```bash
 //! pip install egobox
 //! ```
 //!
-//! See the [tutorial notebook](https://github.com/relf/egobox/doc/TutorialEgor.ipynb) for usage.
+//! See the [tutorial notebook](https://github.com/relf/egobox/doc/Egor_Tutorial.ipynb) for usage.
 //!
 
 use crate::types::*;

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -303,8 +303,6 @@ impl Egor {
             InfillOptimizer::SLSQP => egobox_ego::InfillOptimizer::Slsqp,
         };
 
-        let doe = self.doe.as_ref().map(|v| v.to_owned());
-
         let xspecs: Vec<XSpec> = self.xspecs.extract(py).expect("Error in xspecs conversion");
         if xspecs.is_empty() {
             panic!("Error: xspecs argument cannot be empty")
@@ -326,20 +324,18 @@ impl Egor {
             })
             .collect();
 
-        let mut mixintegor = egobox_ego::EgorBuilder::optimize(obj);
-
+        let mut mixintegor_build = egobox_ego::EgorBuilder::optimize(obj);
         if let Some(seed) = self.seed {
-            mixintegor = mixintegor.random_seed(seed);
+            mixintegor_build = mixintegor_build.random_seed(seed);
         };
 
-        let mut mixintegor = mixintegor
+        let mut mixintegor = mixintegor_build
             .min_within_mixed_space(&xtypes)
             .n_cstr(self.n_cstr)
             .n_iter(n_iter)
             .n_start(self.n_start)
             .n_doe(self.n_doe)
             .cstr_tol(self.cstr_tol)
-            .doe(doe)
             .regression_spec(egobox_moe::RegressionSpec::from_bits(self.regression_spec.0).unwrap())
             .correlation_spec(
                 egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
@@ -350,6 +346,9 @@ impl Egor {
             .infill_optimizer(infill_optimizer)
             .target(self.target)
             .hot_start(self.hot_start);
+        if let Some(doe) = self.doe.as_ref() {
+            mixintegor = mixintegor.doe(doe);
+        };
         if let Some(kpls_dim) = self.kpls_dim {
             mixintegor = mixintegor.kpls_dim(kpls_dim);
         };

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -332,7 +332,7 @@ impl Egor {
             mixintegor = mixintegor.random_seed(seed);
         };
 
-        let mixintegor = mixintegor
+        let mut mixintegor = mixintegor
             .min_within_mixed_space(&xtypes)
             .n_cstr(self.n_cstr)
             .n_iter(n_iter)
@@ -351,8 +351,10 @@ impl Egor {
             .kpls_dim(self.kpls_dim)
             .n_clusters(self.n_clusters)
             .target(self.target)
-            .outdir(self.outdir.as_ref().cloned())
             .hot_start(self.hot_start);
+        if let Some(outdir) = self.outdir.as_ref().cloned() {
+            mixintegor = mixintegor.outdir(outdir);
+        };
 
         let res = py.allow_threads(|| {
             mixintegor

--- a/src/gpmix.rs
+++ b/src/gpmix.rs
@@ -1,4 +1,15 @@
-use crate::types::*;
+//! `egobox`, Rust toolbox for efficient global optimization
+//!
+//! Thanks to the [PyO3 project](https://pyo3.rs), which makes Rust well suited for building Python extensions,
+//! the mixture of gaussian process surrogates is binded in Python. You can install the Python package using:
+//!
+//! ```bash
+//! pip install egobox
+//! ```
+//!
+//! See the [tutorial notebook](https://github.com/relf/egobox/doc/Gpx_Tutorial.ipynb) for usage.
+//!use crate::types::*;
+//!
 use egobox_moe::{Moe, Surrogate};
 use linfa::{traits::Fit, Dataset};
 use ndarray_rand::rand::SeedableRng;
@@ -12,7 +23,7 @@ use rand_xoshiro::Xoshiro256Plus;
 ///         Number of clusters used by the mixture of surrogate experts.
 ///         When set to 0, the number of cluster is determined automatically and refreshed every
 ///         10-points addition (should say 'tentative addition' because addition may fail for some points
-///         but it is counted anyway).
+///         but failures are counted anyway).
 ///
 ///     regr_spec (RegressionSpec flags, an int in [1, 7]):
 ///         Specification of regression models used in mixture.

--- a/src/gpmix.rs
+++ b/src/gpmix.rs
@@ -8,8 +8,8 @@
 //! ```
 //!
 //! See the [tutorial notebook](https://github.com/relf/egobox/doc/Gpx_Tutorial.ipynb) for usage.
-//!use crate::types::*;
 //!
+use crate::types::*;
 use egobox_moe::{Moe, Surrogate};
 use linfa::{traits::Fit, Dataset};
 use ndarray_rand::rand::SeedableRng;


### PR DESCRIPTION
This PR change `Egor` and `EgorSolver` API configuration methods taking an option:
* `outdir`
* `kpls_dim`
* `doe`
* `n_clusters`
Most of the time, those options are set once or not at all so using an `Option` was a bit awkward. Nevertheless, except for the last an `no_<option>()` was added to the API to allow unsetting the option if needed. 