### PR TITLE
Fix Egor service in presence of discrete variables

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -190,14 +190,13 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
 
     /// Runs the (constrained) optimization of the objective function.
     pub fn run(&self) -> Result<OptimResult<f64>> {
-        let no_discrete = self.solver.config.no_discrete;
         let xtypes = self.solver.config.xtypes.clone();
 
         let result = Executor::new(self.fobj.clone(), self.solver.clone()).run()?;
         info!("{}", result);
         let (x_data, y_data) = result.state().clone().take_data().unwrap();
 
-        let res = if no_discrete {
+        let res = if !self.solver.config.discrete() {
             info!("History: \n{}", concatenate![Axis(1), x_data, y_data]);
             OptimResult {
                 x_opt: result.state.get_best_param().unwrap().to_owned(),
@@ -206,7 +205,6 @@ impl<O: GroupFunc, SB: SurrogateBuilder> Egor<O, SB> {
                 y_hist: y_data,
             }
         } else {
-            let xtypes = xtypes.unwrap(); // !no_discrete
             let x_data = cast_to_discrete_values(&xtypes, &x_data);
             let x_data = fold_with_enum_index(&xtypes, &x_data.view());
             info!("History: \n{}", concatenate![Axis(1), x_data, y_data]);

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -142,10 +142,13 @@ impl<O: GroupFunc> EgorBuilder<O> {
         } else {
             Xoshiro256Plus::from_entropy()
         };
-        let xtypes = to_xtypes(xlimits);
+        let config = EgorConfig {
+            xtypes: to_xtypes(xlimits),
+            ..self.config.clone()
+        };
         Egor {
             fobj: ObjFunc::new(self.fobj),
-            solver: EgorSolver::new(self.config, &xtypes, rng),
+            solver: EgorSolver::new(config, rng),
         }
     }
 
@@ -158,9 +161,13 @@ impl<O: GroupFunc> EgorBuilder<O> {
         } else {
             Xoshiro256Plus::from_entropy()
         };
+        let config = EgorConfig {
+            xtypes: xtypes.into(),
+            ..self.config.clone()
+        };
         Egor {
             fobj: ObjFunc::new(self.fobj),
-            solver: EgorSolver::new(self.config, xtypes, rng),
+            solver: EgorSolver::new(config, rng),
         }
     }
 }

--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -142,9 +142,10 @@ impl<O: GroupFunc> EgorBuilder<O> {
         } else {
             Xoshiro256Plus::from_entropy()
         };
+        let xtypes = to_xtypes(xlimits);
         Egor {
             fobj: ObjFunc::new(self.fobj),
-            solver: EgorSolver::new(self.config, xlimits, rng),
+            solver: EgorSolver::new(self.config, &xtypes, rng),
         }
     }
 
@@ -159,7 +160,7 @@ impl<O: GroupFunc> EgorBuilder<O> {
         };
         Egor {
             fobj: ObjFunc::new(self.fobj),
-            solver: EgorSolver::new_with_xtypes(self.config, xtypes, rng),
+            solver: EgorSolver::new(self.config, xtypes, rng),
         }
     }
 }

--- a/ego/src/egor_config.rs
+++ b/ego/src/egor_config.rs
@@ -235,6 +235,12 @@ impl EgorConfig {
         self
     }
 
+    /// Define design space with given x types
+    pub fn xtypes(mut self, xtypes: &[XType]) -> Self {
+        self.xtypes = xtypes.into();
+        self
+    }
+
     /// Check whether we are in a discrete optimization context
     pub fn discrete(&self) -> bool {
         crate::utils::discrete(&self.xtypes)

--- a/ego/src/egor_config.rs
+++ b/ego/src/egor_config.rs
@@ -54,9 +54,7 @@ pub struct EgorConfig {
     /// If true use `outdir` to retrieve and start from previous results
     pub(crate) hot_start: bool,
     /// List of x types allowing the handling of discrete input variables
-    pub(crate) xtypes: Option<Vec<XType>>,
-    /// Flag for discrete handling, true if mixed-integer type present in xtypes, otherwise false
-    pub(crate) no_discrete: bool,
+    pub(crate) xtypes: Vec<XType>,
     /// A random generator seed used to get reproductible results.
     pub(crate) seed: Option<u64>,
 }
@@ -81,8 +79,7 @@ impl Default for EgorConfig {
             target: f64::NEG_INFINITY,
             outdir: None,
             hot_start: false,
-            xtypes: None,
-            no_discrete: true,
+            xtypes: vec![],
             seed: None,
         }
     }
@@ -236,5 +233,10 @@ impl EgorConfig {
     pub fn random_seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
         self
+    }
+
+    /// Check whether we are in a discrete optimization context
+    pub fn discrete(&self) -> bool {
+        crate::utils::discrete(&self.xtypes)
     }
 }

--- a/ego/src/egor_service.rs
+++ b/ego/src/egor_service.rs
@@ -88,7 +88,7 @@ impl EgorServiceBuilder {
         };
         EgorService {
             config: EgorConfig {
-                xtypes: Some(continuous_xlimits_to_xtypes(xlimits)),
+                xtypes: Some(to_xtypes(xlimits)),
                 ..self.config.clone()
             },
             solver: EgorSolver::new(self.config, xlimits, rng),

--- a/ego/src/egor_service.rs
+++ b/ego/src/egor_service.rs
@@ -89,7 +89,7 @@ impl EgorServiceBuilder {
         let xtypes = to_xtypes(xlimits);
         EgorService {
             config: EgorConfig {
-                xtypes: Some(xtypes.clone()),
+                xtypes: xtypes.clone(),
                 ..self.config.clone()
             },
             solver: EgorSolver::new(self.config, &xtypes, rng),
@@ -107,7 +107,7 @@ impl EgorServiceBuilder {
         };
         EgorService {
             config: EgorConfig {
-                xtypes: Some(xtypes.to_vec()),
+                xtypes: xtypes.to_vec(),
                 ..self.config.clone()
             },
             solver: EgorSolver::new(self.config, xtypes, rng),
@@ -137,7 +137,7 @@ impl<SB: SurrogateBuilder> EgorService<SB> {
         x_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
         y_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Array2<f64> {
-        let xtypes = self.config.xtypes.as_ref().unwrap();
+        let xtypes = &self.config.xtypes;
         let x_data = unfold_with_enum_mask(xtypes, x_data);
         let x = self.solver.suggest(&x_data, y_data);
         let x = cast_to_discrete_values(xtypes, &x);

--- a/ego/src/egor_service.rs
+++ b/ego/src/egor_service.rs
@@ -86,12 +86,13 @@ impl EgorServiceBuilder {
         } else {
             Xoshiro256Plus::from_entropy()
         };
+        let xtypes = to_xtypes(xlimits);
         EgorService {
             config: EgorConfig {
-                xtypes: Some(to_xtypes(xlimits)),
+                xtypes: Some(xtypes.clone()),
                 ..self.config.clone()
             },
-            solver: EgorSolver::new(self.config, xlimits, rng),
+            solver: EgorSolver::new(self.config, &xtypes, rng),
         }
     }
 
@@ -109,7 +110,7 @@ impl EgorServiceBuilder {
                 xtypes: Some(xtypes.to_vec()),
                 ..self.config.clone()
             },
-            solver: EgorSolver::new_with_xtypes(self.config, xtypes, rng),
+            solver: EgorSolver::new(self.config, xtypes, rng),
         }
     }
 }

--- a/ego/src/egor_service.rs
+++ b/ego/src/egor_service.rs
@@ -86,13 +86,12 @@ impl EgorServiceBuilder {
         } else {
             Xoshiro256Plus::from_entropy()
         };
-        let xtypes = to_xtypes(xlimits);
+        let config = EgorConfig {
+            xtypes: to_xtypes(xlimits),
+            ..self.config.clone()
+        };
         EgorService {
-            config: EgorConfig {
-                xtypes: xtypes.clone(),
-                ..self.config.clone()
-            },
-            solver: EgorSolver::new(self.config, &xtypes, rng),
+            solver: EgorSolver::new(config, rng),
         }
     }
 
@@ -105,12 +104,12 @@ impl EgorServiceBuilder {
         } else {
             Xoshiro256Plus::from_entropy()
         };
+        let config = EgorConfig {
+            xtypes: xtypes.to_vec(),
+            ..self.config.clone()
+        };
         EgorService {
-            config: EgorConfig {
-                xtypes: xtypes.to_vec(),
-                ..self.config.clone()
-            },
-            solver: EgorSolver::new(self.config, xtypes, rng),
+            solver: EgorSolver::new(config, rng),
         }
     }
 }
@@ -118,16 +117,10 @@ impl EgorServiceBuilder {
 /// Egor optimizer service.
 #[derive(Clone)]
 pub struct EgorService<SB: SurrogateBuilder> {
-    config: EgorConfig,
     solver: EgorSolver<SB>,
 }
 
 impl<SB: SurrogateBuilder> EgorService<SB> {
-    pub fn configure<F: FnOnce(EgorConfig) -> EgorConfig>(mut self, init: F) -> Self {
-        self.config = init(self.config);
-        self
-    }
-
     /// Given an evaluated doe (x, y) data, return the next promising x point
     /// where optimum may occurs regarding the infill criterium.
     /// This function inverse the control of the optimization and can used
@@ -137,7 +130,7 @@ impl<SB: SurrogateBuilder> EgorService<SB> {
         x_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
         y_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Array2<f64> {
-        let xtypes = &self.config.xtypes;
+        let xtypes = &self.solver.config.xtypes;
         let x_data = unfold_with_enum_mask(xtypes, x_data);
         let x = self.solver.suggest(&x_data, y_data);
         let x = cast_to_discrete_values(xtypes, &x);

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -232,11 +232,11 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
         builder.try_init().ok();
         EgorSolver {
             config: EgorConfig {
-                xtypes: Some(continuous_xlimits_to_xtypes(xlimits)), // align xlimits and xtypes
+                xtypes: Some(to_xtypes(xlimits)), // align xlimits and xtypes
                 ..config
             },
             xlimits: xlimits.to_owned(),
-            surrogate_builder: SB::new_with_xtypes(&continuous_xlimits_to_xtypes(xlimits)),
+            surrogate_builder: SB::new_with_xtypes(&to_xtypes(xlimits)),
             rng,
         }
     }
@@ -299,7 +299,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
 /// Build `xtypes` from simple float bounds of `x` input components when x belongs to R^n.
 /// xlimits are bounds of the x components expressed a matrix (dim, 2) where dim is the dimension of x
 /// the ith row is the bounds interval [lower, upper] of the ith comonent of `x`.  
-pub fn continuous_xlimits_to_xtypes(xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>) -> Vec<XType> {
+pub fn to_xtypes(xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>) -> Vec<XType> {
     let mut xtypes: Vec<XType> = vec![];
     Zip::from(xlimits.rows()).for_each(|limits| xtypes.push(XType::Cont(limits[0], limits[1])));
     xtypes

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -165,7 +165,7 @@ pub struct EgorSolver<SB: SurrogateBuilder> {
 impl SurrogateBuilder for MoeParams<f64, Xoshiro256Plus> {
     /// Constructor from domain space specified with types
     /// **panic** if xtypes contains other types than continuous type `Float`
-    fn new_with_xtypes_rng(xtypes: &[XType]) -> Self {
+    fn new_with_xtypes(xtypes: &[XType]) -> Self {
         if !no_discrete(xtypes) {
             panic!("MoeParams cannot be created with discrete types!");
         }
@@ -236,7 +236,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
                 ..config
             },
             xlimits: xlimits.to_owned(),
-            surrogate_builder: SB::new_with_xtypes_rng(&continuous_xlimits_to_xtypes(xlimits)),
+            surrogate_builder: SB::new_with_xtypes(&continuous_xlimits_to_xtypes(xlimits)),
             rng,
         }
     }
@@ -260,7 +260,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
                 ..config
             },
             xlimits: unfold_xtypes_as_continuous_limits(xtypes),
-            surrogate_builder: SB::new_with_xtypes_rng(xtypes),
+            surrogate_builder: SB::new_with_xtypes(xtypes),
             rng,
         }
     }
@@ -299,7 +299,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
 /// Build `xtypes` from simple float bounds of `x` input components when x belongs to R^n.
 /// xlimits are bounds of the x components expressed a matrix (dim, 2) where dim is the dimension of x
 /// the ith row is the bounds interval [lower, upper] of the ith comonent of `x`.  
-fn continuous_xlimits_to_xtypes(xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>) -> Vec<XType> {
+pub fn continuous_xlimits_to_xtypes(xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>) -> Vec<XType> {
     let mut xtypes: Vec<XType> = vec![];
     Zip::from(xlimits.rows()).for_each(|limits| xtypes.push(XType::Cont(limits[0], limits[1])));
     xtypes

--- a/ego/src/lhs_optimizer.rs
+++ b/ego/src/lhs_optimizer.rs
@@ -121,7 +121,7 @@ impl<'a, R: Rng + Clone + Sync + Send> LhsOptimizer<'a, R> {
                     err
                 );
                 if values.is_empty() {
-                    log::info!("No valid value maybe due to ill-formed surrogate models");
+                    log::error!("No valid output value maybe due to ill-formed surrogate models.");
                 }
                 panic!("Optimization Aborted!")
             });

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -108,7 +108,7 @@ fn compute_unfolded_dimension(xtypes: &[XType]) -> usize {
 /// For instance, if an input dimension is typed ["blue", "red", "green"] a sample/row of
 /// the input x may contain [..., 2, ...] which will be expanded in [..., 0, 0, 1, ...].
 /// This function is the opposite of fold_with_enum_index().
-fn unfold_with_enum_mask(
+pub fn unfold_with_enum_mask(
     xtypes: &[XType],
     x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
 ) -> Array2<f64> {
@@ -310,7 +310,7 @@ impl MixintMoeParams {
         self
     }
 
-    /// Sets the specification
+    /// Gets the domain specification
     pub fn xtypes(&self) -> &[XType] {
         &self.0.xtypes
     }

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -487,10 +487,10 @@ pub struct MixintMoe {
 
 impl std::fmt::Display for MixintMoe {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let prefix = if crate::utils::no_discrete(&self.xtypes) {
-            ""
-        } else {
+        let prefix = if crate::utils::discrete(&self.xtypes) {
             "MixInt"
+        } else {
+            ""
         };
         write!(f, "{}{}", prefix, &self.moe)
     }

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -114,7 +114,7 @@ pub fn unfold_with_enum_mask(
 ) -> Array2<f64> {
     let mut xunfold = Array::zeros((x.nrows(), compute_unfolded_dimension(xtypes)));
     let mut unfold_index = 0;
-    xtypes.iter().for_each(|s| match s {
+    xtypes.iter().enumerate().for_each(|(i, s)| match s {
         XType::Cont(_, _) | XType::Int(_, _) | XType::Ord(_) => {
             xunfold
                 .column_mut(unfold_index)
@@ -126,8 +126,8 @@ pub fn unfold_with_enum_mask(
             Zip::from(unfold.rows_mut())
                 .and(x.rows())
                 .for_each(|mut row, xrow| {
-                    let index = xrow[[unfold_index]] as usize;
-                    row[[index]] = 1.;
+                    let index = xrow[i] as usize;
+                    row[index] = 1.;
                 });
             xunfold
                 .slice_mut(s![.., unfold_index..unfold_index + v])
@@ -368,7 +368,7 @@ impl MixintMoeValidParams {
 }
 
 impl SurrogateBuilder for MixintMoeParams {
-    fn new_with_xtypes_rng(xtypes: &[XType]) -> Self {
+    fn new_with_xtypes(xtypes: &[XType]) -> Self {
         MixintMoeParams::new(xtypes, &MoeParams::new())
     }
 

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -234,6 +234,7 @@ impl<F: Float, S: egobox_doe::SamplingMethod<F>> MixintSampling<F, S> {
     }
 
     /// Sets whether we want to work in folded space
+    /// If set, sampling data will be provided in folded space
     pub fn work_in_folded_space(&mut self, output_in_folded_space: bool) -> &mut Self {
         self.output_in_folded_space = output_in_folded_space;
         self
@@ -279,7 +280,8 @@ pub struct MixintMoeValidParams {
 }
 
 impl MixintMoeValidParams {
-    /// Sets whether we want to work in folded space
+    /// Sets whether we want to work in folded space that is whether
+    /// If set, input training data has to be given in folded space
     pub fn work_in_folded_space(&self) -> bool {
         self.work_in_folded_space
     }
@@ -478,7 +480,7 @@ pub struct MixintMoe {
     moe: Moe,
     /// The input specifications
     xtypes: Vec<XType>,
-    /// whether data are in given in folded space (enum indexes) or not (enum masks)
+    /// whether training input data are in given in folded space (enum indexes) or not (enum masks)
     /// i.e for "blue" in ["red", "green", "blue"] either \[2\] or [0, 0, 1]
     work_in_folded_space: bool,
 }
@@ -623,11 +625,13 @@ pub struct MixintContext {
     xtypes: Vec<XType>,
     /// whether data are in given in folded space (enum indexes) or not (enum masks)
     /// i.e for "blue" in ["red", "green", "blue"] either \[2\] or [0, 0, 1]
+    /// For sampling data refers to DOE data. For surrogate data refers to training input data
     work_in_folded_space: bool,
 }
 
 impl MixintContext {
     /// Constructor with given `xtypes` specification
+    /// where working in folded space is the default
     pub fn new(xtypes: &[XType]) -> Self {
         MixintContext {
             xtypes: xtypes.to_vec(),

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -108,7 +108,8 @@ pub enum XType {
 /// The output surrogate used by [crate::Egor] is expected to model either
 /// objective function or constraint functions
 pub trait SurrogateBuilder: Clone + Serialize + Sync {
-    fn new_with_xtypes_rng(xtypes: &[XType]) -> Self;
+    /// Constructor from domain space specified with types.
+    fn new_with_xtypes(xtypes: &[XType]) -> Self;
 
     /// Sets the allowed regression models used in gaussian processes.
     fn set_regression_spec(&mut self, regression_spec: RegressionSpec);

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -76,8 +76,8 @@ pub fn update_data(
     appended
 }
 
-pub fn no_discrete(xtypes: &[XType]) -> bool {
-    !xtypes
+pub fn discrete(xtypes: &[XType]) -> bool {
+    xtypes
         .iter()
         .any(|t| matches!(t, &XType::Int(_, _) | &XType::Ord(_) | &XType::Enum(_)))
 }


### PR DESCRIPTION
This PR fixes `suggest()` method in order to accept DOE data input data and provide x suggestion in discrete space. 
It also fixes bugs and awkward API related to `xlimits` vs `xtypes` for discrete optimization:
* Remove wrong LHS optimisation parallel execution when rng is set (same point was drawn! Should be reworked)
* Fix `unfold_with enum_mask` indices bug
* EgorSolver constructor with xlimits is removed, hence new accepts xtypes now
* Clean up API `Egor`, `EgorService`, `EgorConfig`
* Improve error messages and comments in mixed-integer context.
