### PR TITLE
Add Gpx accessors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - windows-latest
           - macos-latest
         include:
-          - toolchain: 1.70.0  # test MSRV
+          - toolchain: 1.74.0  # test MSRV
             os: ubuntu-latest
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
   "optimization",
 ]
 categories = ["algorithms", "mathematics", "science"]
-rust-version = "1.70" # MSVR
+rust-version = "1.74" # MSVR
 
 exclude = [".github/"]
 

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -50,7 +50,7 @@ log = "0.4"
 env_logger = "0.10.0"
 thiserror = "1"
 anyhow = "1"
-clap = { version = "<4.5", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/ego/src/criteria/ei.rs
+++ b/ego/src/criteria/ei.rs
@@ -1,6 +1,6 @@
 use crate::criteria::InfillCriterion;
 use crate::utils::{norm_cdf, norm_pdf};
-use egobox_moe::ClusteredSurrogate;
+use egobox_moe::MixtureGpSurrogate;
 use ndarray::{Array1, ArrayView};
 
 use serde::{Deserialize, Serialize};
@@ -17,7 +17,7 @@ impl InfillCriterion for ExpectedImprovement {
     fn value(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         _scale: Option<f64>,
     ) -> f64 {
@@ -43,7 +43,7 @@ impl InfillCriterion for ExpectedImprovement {
     fn grad(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         _scale: Option<f64>,
     ) -> Array1<f64> {
@@ -84,7 +84,7 @@ impl InfillCriterion for ExpectedImprovement {
     fn scaling(
         &self,
         _x: &ndarray::ArrayView2<f64>,
-        _obj_model: &dyn ClusteredSurrogate,
+        _obj_model: &dyn MixtureGpSurrogate,
         _f_min: f64,
     ) -> f64 {
         1.0

--- a/ego/src/criteria/mod.rs
+++ b/ego/src/criteria/mod.rs
@@ -5,7 +5,7 @@ pub use ei::{ExpectedImprovement, EI};
 pub use wb2::{WB2Criterion, WB2, WB2S};
 
 use dyn_clonable::*;
-use egobox_moe::ClusteredSurrogate;
+use egobox_moe::MixtureGpSurrogate;
 use ndarray::{Array1, ArrayView2};
 
 /// A trait for infill criterion which maximmum location will
@@ -20,7 +20,7 @@ pub trait InfillCriterion: Clone + Sync {
     fn value(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         scale: Option<f64>,
     ) -> f64;
@@ -29,11 +29,11 @@ pub trait InfillCriterion: Clone + Sync {
     fn grad(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         scale: Option<f64>,
     ) -> Array1<f64>;
 
     /// Scaling factor computation
-    fn scaling(&self, x: &ArrayView2<f64>, obj_model: &dyn ClusteredSurrogate, f_min: f64) -> f64;
+    fn scaling(&self, x: &ArrayView2<f64>, obj_model: &dyn MixtureGpSurrogate, f_min: f64) -> f64;
 }

--- a/ego/src/criteria/wb2.rs
+++ b/ego/src/criteria/wb2.rs
@@ -1,6 +1,6 @@
 use crate::criteria::{ei::EI, InfillCriterion};
 
-use egobox_moe::ClusteredSurrogate;
+use egobox_moe::MixtureGpSurrogate;
 use ndarray::{Array1, ArrayView, ArrayView2, Axis};
 use ndarray_stats::QuantileExt;
 
@@ -16,7 +16,7 @@ impl InfillCriterion for WB2Criterion {
     fn value(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         scale: Option<f64>,
     ) -> f64 {
@@ -31,7 +31,7 @@ impl InfillCriterion for WB2Criterion {
     fn grad(
         &self,
         x: &[f64],
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
         scale: Option<f64>,
     ) -> Array1<f64> {
@@ -44,7 +44,7 @@ impl InfillCriterion for WB2Criterion {
     fn scaling(
         &self,
         x: &ndarray::ArrayView2<f64>,
-        obj_model: &dyn ClusteredSurrogate,
+        obj_model: &dyn MixtureGpSurrogate,
         f_min: f64,
     ) -> f64 {
         if let Some(scale) = self.0 {
@@ -58,7 +58,7 @@ impl InfillCriterion for WB2Criterion {
 /// Computes the scaling factor used to scale WB2 infill criteria.
 pub(crate) fn compute_wb2s_scale(
     x: &ArrayView2<f64>,
-    obj_model: &dyn ClusteredSurrogate,
+    obj_model: &dyn MixtureGpSurrogate,
     f_min: f64,
 ) -> f64 {
     let ratio = 100.; // TODO: make it a parameter
@@ -106,7 +106,7 @@ mod tests {
             .recombination(Recombination::Hard)
             .fit(&Dataset::new(xt, yt))
             .expect("GP fitting");
-        let bgp = Box::new(gp) as Box<dyn ClusteredSurrogate>;
+        let bgp = Box::new(gp) as Box<dyn MixtureGpSurrogate>;
 
         let h = 1e-4;
         let x1 = 0.1;

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -6,8 +6,8 @@ use crate::errors::{EgoError, Result};
 use crate::types::{SurrogateBuilder, XType};
 use egobox_doe::{FullFactorial, Lhs, LhsKind, Random};
 use egobox_moe::{
-    Clustered, ClusteredSurrogate, Clustering, CorrelationSpec, FullGpSurrogate, GpMixParams,
-    GpMixture, GpSurrogate, RegressionSpec,
+    Clustered, Clustering, CorrelationSpec, FullGpSurrogate, GpMixParams, GpMixture, GpSurrogate,
+    MixtureGpSurrogate, RegressionSpec,
 };
 use linfa::traits::{Fit, PredictInplace};
 use linfa::{DatasetBase, Float, ParamGuard};
@@ -440,9 +440,9 @@ impl SurrogateBuilder for MixintGpMixParams {
         &self,
         xt: &ArrayView2<f64>,
         yt: &ArrayView2<f64>,
-    ) -> Result<Box<dyn ClusteredSurrogate>> {
+    ) -> Result<Box<dyn MixtureGpSurrogate>> {
         let mixmoe = self.check_ref()?._train(xt, yt)?;
-        Ok(mixmoe).map(|mixmoe| Box::new(mixmoe) as Box<dyn ClusteredSurrogate>)
+        Ok(mixmoe).map(|mixmoe| Box::new(mixmoe) as Box<dyn MixtureGpSurrogate>)
     }
 
     fn train_on_clusters(
@@ -450,9 +450,9 @@ impl SurrogateBuilder for MixintGpMixParams {
         xt: &ArrayView2<f64>,
         yt: &ArrayView2<f64>,
         clustering: &Clustering,
-    ) -> Result<Box<dyn ClusteredSurrogate>> {
+    ) -> Result<Box<dyn MixtureGpSurrogate>> {
         let mixmoe = self.check_ref()?._train_on_clusters(xt, yt, clustering)?;
-        Ok(mixmoe).map(|mixmoe| Box::new(mixmoe) as Box<dyn ClusteredSurrogate>)
+        Ok(mixmoe).map(|mixmoe| Box::new(mixmoe) as Box<dyn MixtureGpSurrogate>)
     }
 }
 
@@ -597,7 +597,7 @@ impl FullGpSurrogate for MixintMoe {
     }
 }
 
-impl ClusteredSurrogate for MixintMoe {
+impl MixtureGpSurrogate for MixintMoe {
     fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
         self.moe.experts()
     }

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -7,7 +7,7 @@ use crate::types::{SurrogateBuilder, XType};
 use egobox_doe::{FullFactorial, Lhs, LhsKind, Random};
 use egobox_moe::{
     Clustered, Clustering, CorrelationSpec, FullGpSurrogate, GpMixParams, GpMixture, GpSurrogate,
-    MixtureGpSurrogate, RegressionSpec,
+    GpSurrogateExt, MixtureGpSurrogate, RegressionSpec,
 };
 use linfa::traits::{Fit, PredictInplace};
 use linfa::{DatasetBase, Float, ParamGuard};
@@ -565,7 +565,7 @@ impl GpSurrogate for MixintMoe {
 }
 
 #[typetag::serde]
-impl FullGpSurrogate for MixintMoe {
+impl GpSurrogateExt for MixintMoe {
     fn predict_derivatives(&self, x: &ArrayView2<f64>) -> egobox_moe::Result<Array2<f64>> {
         let mut xcast = if self.work_in_folded_space {
             unfold_with_enum_mask(&self.xtypes, x)
@@ -598,7 +598,7 @@ impl FullGpSurrogate for MixintMoe {
 }
 
 impl MixtureGpSurrogate for MixintMoe {
-    fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
+    fn experts(&self) -> &Vec<Box<dyn FullGpSurrogate>> {
         self.moe.experts()
     }
 }

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -597,7 +597,11 @@ impl FullGpSurrogate for MixintMoe {
     }
 }
 
-impl ClusteredSurrogate for MixintMoe {}
+impl ClusteredSurrogate for MixintMoe {
+    fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
+        self.moe.experts()
+    }
+}
 
 impl<D: Data<Elem = f64>> PredictInplace<ArrayBase<D, Ix2>, Array2<f64>> for MixintMoe {
     fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<f64>) {

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -1,6 +1,6 @@
 use crate::errors::Result;
 use argmin::core::CostFunction;
-use egobox_moe::{ClusteredSurrogate, Clustering};
+use egobox_moe::{Clustering, MixtureGpSurrogate};
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
 use serde::{Deserialize, Serialize};
@@ -128,7 +128,7 @@ pub trait SurrogateBuilder: Clone + Serialize + Sync {
         &self,
         xt: &ArrayView2<f64>,
         yt: &ArrayView2<f64>,
-    ) -> Result<Box<dyn ClusteredSurrogate>>;
+    ) -> Result<Box<dyn MixtureGpSurrogate>>;
 
     /// Train the surrogate with given training dataset (x, y) and given clustering
     fn train_on_clusters(
@@ -136,7 +136,7 @@ pub trait SurrogateBuilder: Clone + Serialize + Sync {
         xt: &ArrayView2<f64>,
         yt: &ArrayView2<f64>,
         clustering: &Clustering,
-    ) -> Result<Box<dyn ClusteredSurrogate>>;
+    ) -> Result<Box<dyn MixtureGpSurrogate>>;
 }
 
 pub trait ObjFn<U>: Fn(&[f64], Option<&mut [f64]>, &mut U) -> f64 {}

--- a/ego/src/utils.rs
+++ b/ego/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::types::XType;
-use egobox_moe::ClusteredSurrogate;
+use egobox_moe::MixtureGpSurrogate;
 use libm::erfc;
 use ndarray::{concatenate, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, Ix1, Ix2, Zip};
 use ndarray_stats::{DeviationExt, QuantileExt};
@@ -9,7 +9,7 @@ const SQRT_2PI: f64 = 2.5066282746310007;
 /// Computes scaling factors used to scale constraint functions values.
 pub fn compute_cstr_scales(
     x: &ArrayView2<f64>,
-    cstr_models: &[Box<dyn ClusteredSurrogate>],
+    cstr_models: &[Box<dyn MixtureGpSurrogate>],
 ) -> Array1<f64> {
     let scales: Vec<f64> = cstr_models
         .par_iter()

--- a/gp/src/sparse_algorithm.rs
+++ b/gp/src/sparse_algorithm.rs
@@ -287,6 +287,11 @@ impl<F: Float, Corr: CorrelationModel<F>> SparseGaussianProcess<F, Corr> {
         self.noise
     }
 
+    /// Retrieve reduced likelihood value
+    pub fn likelihood(&self) -> F {
+        self.likelihood
+    }
+
     /// Inducing points
     pub fn inducings(&self) -> &Array2<F> {
         &self.inducings

--- a/gp/src/sparse_algorithm.rs
+++ b/gp/src/sparse_algorithm.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::optimize_params;
 use crate::errors::{GpError, Result};
 use crate::sparse_parameters::{
-    Inducings, SgpParams, SgpValidParams, SparseMethod, VarianceEstimation,
+    Inducings, ParamEstimation, SgpParams, SgpValidParams, SparseMethod,
 };
 use crate::{correlation_models::*, utils::pairwise_differences};
 use crate::{prepare_multistart, CobylaParams};
@@ -57,7 +57,7 @@ impl<F: Float> Clone for WoodburyData<F> {
 ///
 /// [`SparseGaussianProcess`] inducing points definition can be either random or provided by the user through
 /// the [`Inducings`] specification. The used sparse method is specified with the [`SparseMethod`].
-/// Noise variance can be either specified as a known constant or estimated (see [`VarianceEstimation`]).
+/// Noise variance can be either specified as a known constant or estimated (see [`ParamEstimation`]).
 /// Unlike [`GaussianProcess`]([crate::GaussianProcess]) implementation [`SparseGaussianProcess`]
 /// does not allow choosing a trend which is supposed to be zero.
 /// The correlation kernel might be selected amongst [available kernels](crate::correlation_models).
@@ -405,8 +405,8 @@ impl<F: Float, Corr: CorrelationModel<F>, D: Data<Elem = F> + Sync>
 
         // Initial guess for noise, when noise variance constant, it is not part of optimization params
         let (is_noise_estimated, noise0) = match self.noise_variance() {
-            VarianceEstimation::Constant(c) => (false, c),
-            VarianceEstimation::Estimated {
+            ParamEstimation::Fixed(c) => (false, c),
+            ParamEstimation::Estimated {
                 initial_guess: c,
                 bounds: _,
             } => (true, c),
@@ -498,7 +498,7 @@ impl<F: Float, Corr: CorrelationModel<F>, D: Data<Elem = F> + Sync>
         bounds[params.ncols() - 1 - is_noise_estimated as usize] =
             (F::cast(1e-12).log10(), (F::cast(9.) * sigma2_0).log10());
         // optionally adjust noise variance bounds
-        if let VarianceEstimation::Estimated {
+        if let ParamEstimation::Estimated {
             initial_guess: _,
             bounds: (lo, up),
         } = self.noise_variance()
@@ -849,7 +849,7 @@ mod tests {
 
         let sgp = SparseKriging::params(Inducings::Randomized(n_inducings))
             //let sgp = SparseKriging::params(Inducings::Located(z))
-            //.noise_variance(VarianceEstimation::Constant(0.01))
+            //.noise_variance(ParamEstimation::Constant(0.01))
             .seed(Some(42))
             .fit(&Dataset::new(xt.clone(), yt.clone()))
             .expect("GP fitted");
@@ -896,7 +896,7 @@ mod tests {
             Inducings::Located(z),
         )
         .sparse_method(SparseMethod::Vfe)
-        .noise_variance(VarianceEstimation::Constant(0.01))
+        .noise_variance(ParamEstimation::Fixed(0.01))
         .fit(&Dataset::new(xt.clone(), yt.clone()))
         .expect("GP fitted");
 
@@ -939,7 +939,7 @@ mod tests {
         .sparse_method(SparseMethod::Vfe)
         //.sparse_method(SparseMethod::Fitc)
         .theta_init(vec![0.1])
-        .noise_variance(VarianceEstimation::Estimated {
+        .noise_variance(ParamEstimation::Estimated {
             initial_guess: 0.02,
             bounds: (1e-3, 1.),
         })

--- a/gp/src/sparse_parameters.rs
+++ b/gp/src/sparse_parameters.rs
@@ -10,14 +10,14 @@ use serde::{Deserialize, Serialize};
 
 /// Variance estimation method
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum VarianceEstimation<F: Float> {
-    /// Constant variance (ie given not estimated)
-    Constant(F),
-    /// Variance is estimated between given bounds (lower, upper) starting from the inital guess
+pub enum ParamEstimation<F: Float> {
+    /// Constant parameter (ie given not estimated)
+    Fixed(F),
+    /// Parameter is estimated between given bounds (lower, upper) starting from the inital guess
     Estimated { initial_guess: F, bounds: (F, F) },
 }
-impl<F: Float> Default for VarianceEstimation<F> {
-    fn default() -> VarianceEstimation<F> {
+impl<F: Float> Default for ParamEstimation<F> {
+    fn default() -> ParamEstimation<F> {
         Self::Estimated {
             initial_guess: F::cast(1e-2),
             bounds: (F::cast(100.0) * F::epsilon(), F::cast(1e10)),
@@ -58,7 +58,7 @@ pub struct SgpValidParams<F: Float, Corr: CorrelationModel<F>> {
     /// gp
     gp_params: GpValidParams<F, ConstantMean, Corr>,
     /// Gaussian homeoscedastic noise variance
-    noise: VarianceEstimation<F>,
+    noise: ParamEstimation<F>,
     /// Inducing points
     z: Inducings<F>,
     /// Method
@@ -71,7 +71,7 @@ impl<F: Float> Default for SgpValidParams<F, SquaredExponentialCorr> {
     fn default() -> SgpValidParams<F, SquaredExponentialCorr> {
         SgpValidParams {
             gp_params: GpValidParams::default(),
-            noise: VarianceEstimation::default(),
+            noise: ParamEstimation::default(),
             z: Inducings::default(),
             method: SparseMethod::default(),
             seed: None,
@@ -116,7 +116,7 @@ impl<F: Float, Corr: CorrelationModel<F>> SgpValidParams<F, Corr> {
     }
 
     /// Get noise variance configuration
-    pub fn noise_variance(&self) -> &VarianceEstimation<F> {
+    pub fn noise_variance(&self) -> &ParamEstimation<F> {
         &self.noise
     }
 
@@ -143,7 +143,7 @@ impl<F: Float, Corr: CorrelationModel<F>> SgpParams<F, Corr> {
                 n_start: 10,
                 nugget: F::cast(1000.0) * F::epsilon(),
             },
-            noise: VarianceEstimation::default(),
+            noise: ParamEstimation::default(),
             z: inducings,
             method: SparseMethod::default(),
             seed: None,
@@ -227,7 +227,7 @@ impl<F: Float, Corr: CorrelationModel<F>> SgpParams<F, Corr> {
     }
 
     /// Set noise variance configuration defining noise handling.
-    pub fn noise_variance(mut self, config: VarianceEstimation<F>) -> Self {
+    pub fn noise_variance(mut self, config: ParamEstimation<F>) -> Self {
         self.0.noise = config;
         self
     }

--- a/moe/src/gp_algorithm.rs
+++ b/moe/src/gp_algorithm.rs
@@ -460,7 +460,12 @@ impl FullGpSurrogate for GpMixture {
     }
 }
 
-impl ClusteredSurrogate for GpMixture {}
+impl ClusteredSurrogate for GpMixture {
+    /// Selected experts in the mixture
+    fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
+        &self.experts
+    }
+}
 
 impl GpMixture {
     /// Constructor of mixture of experts parameters
@@ -471,11 +476,6 @@ impl GpMixture {
     /// Recombination mode
     pub fn recombination(&self) -> Recombination<f64> {
         self.recombination
-    }
-
-    /// Selected experts in the mixture
-    pub fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
-        &self.experts
     }
 
     /// Gaussian mixture

--- a/moe/src/gp_algorithm.rs
+++ b/moe/src/gp_algorithm.rs
@@ -460,7 +460,7 @@ impl FullGpSurrogate for GpMixture {
     }
 }
 
-impl ClusteredSurrogate for GpMixture {
+impl MixtureGpSurrogate for GpMixture {
     /// Selected experts in the mixture
     fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
         &self.experts

--- a/moe/src/gp_algorithm.rs
+++ b/moe/src/gp_algorithm.rs
@@ -434,7 +434,7 @@ impl GpSurrogate for GpMixture {
 }
 
 #[cfg_attr(feature = "serializable", typetag::serde)]
-impl FullGpSurrogate for GpMixture {
+impl GpSurrogateExt for GpMixture {
     fn predict_derivatives(&self, x: &ArrayView2<f64>) -> Result<Array2<f64>> {
         match self.recombination {
             Recombination::Hard => self.predict_derivatives_hard(x),
@@ -462,7 +462,7 @@ impl FullGpSurrogate for GpMixture {
 
 impl MixtureGpSurrogate for GpMixture {
     /// Selected experts in the mixture
-    fn experts(&self) -> &[Box<dyn FullGpSurrogate>] {
+    fn experts(&self) -> &Vec<Box<dyn FullGpSurrogate>> {
         &self.experts
     }
 }
@@ -764,14 +764,14 @@ impl GpMixture {
         &self,
         x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Result<Array2<f64>> {
-        <GpMixture as FullGpSurrogate>::predict_derivatives(self, &x.view())
+        <GpMixture as GpSurrogateExt>::predict_derivatives(self, &x.view())
     }
 
     pub fn predict_variance_derivatives(
         &self,
         x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Result<Array2<f64>> {
-        <GpMixture as FullGpSurrogate>::predict_variance_derivatives(self, &x.view())
+        <GpMixture as GpSurrogateExt>::predict_variance_derivatives(self, &x.view())
     }
 
     #[cfg(feature = "persistent")]
@@ -788,7 +788,7 @@ impl GpMixture {
         x: &ArrayBase<impl Data<Elem = f64>, Ix2>,
         n_traj: usize,
     ) -> Result<Array2<f64>> {
-        <GpMixture as FullGpSurrogate>::sample(self, &x.view(), n_traj)
+        <GpMixture as GpSurrogateExt>::sample(self, &x.view(), n_traj)
     }
 }
 

--- a/moe/src/sgp_algorithm.rs
+++ b/moe/src/sgp_algorithm.rs
@@ -427,8 +427,6 @@ impl GpSurrogate for SparseGpMixture {
     }
 }
 
-impl ClusteredGpSurrogate for SparseGpMixture {}
-
 impl SparseGpMixture {
     /// Constructor of mixture of experts parameters
     pub fn params(inducings: Inducings<f64>) -> SparseGpMixtureParams<f64, Xoshiro256Plus> {

--- a/moe/src/sgp_parameters.rs
+++ b/moe/src/sgp_parameters.rs
@@ -159,7 +159,7 @@ impl<F: Float> SparseGpMixtureParams<F, Xoshiro256Plus> {
 impl<F: Float, R: Rng + SeedableRng + Clone> SparseGpMixtureParams<F, R> {
     /// Constructor of Sgp parameters specifying randon number generator for reproducibility
     ///
-    /// See [`new`](SparseGpMixParams::new) for default parameters.
+    /// See [`new`](SparseGpMixtureParams::new) for default parameters.
     pub fn new_with_rng(inducings: Inducings<F>, rng: R) -> SparseGpMixtureParams<F, R> {
         Self(SparseGpMixtureValidParams {
             n_clusters: 1,

--- a/moe/src/types.rs
+++ b/moe/src/types.rs
@@ -121,9 +121,6 @@ impl Clustering {
     }
 }
 
-/// A trait for Gp surrogates using clustering
-pub trait ClusteredGpSurrogate: Clustered + GpSurrogate {}
-
 /// A trait for Mixture of GP surrogates with derivatives using clustering
 pub trait MixtureGpSurrogate: Clustered + FullGpSurrogate {
     fn experts(&self) -> &[Box<dyn FullGpSurrogate>];

--- a/moe/src/types.rs
+++ b/moe/src/types.rs
@@ -124,5 +124,7 @@ impl Clustering {
 /// A trait for Gp surrogates using clustering
 pub trait ClusteredGpSurrogate: Clustered + GpSurrogate {}
 
-/// A trait for Gp surrogates with derivatives using clustering
-pub trait ClusteredSurrogate: Clustered + FullGpSurrogate {}
+/// A trait for Mixture of GP surrogates with derivatives using clustering
+pub trait ClusteredSurrogate: Clustered + FullGpSurrogate {
+    fn experts(&self) -> &[Box<dyn FullGpSurrogate>];
+}

--- a/moe/src/types.rs
+++ b/moe/src/types.rs
@@ -125,6 +125,6 @@ impl Clustering {
 pub trait ClusteredGpSurrogate: Clustered + GpSurrogate {}
 
 /// A trait for Mixture of GP surrogates with derivatives using clustering
-pub trait ClusteredSurrogate: Clustered + FullGpSurrogate {
+pub trait MixtureGpSurrogate: Clustered + FullGpSurrogate {
     fn experts(&self) -> &[Box<dyn FullGpSurrogate>];
 }

--- a/moe/src/types.rs
+++ b/moe/src/types.rs
@@ -1,5 +1,5 @@
 use crate::gaussian_mixture::GaussianMixture;
-use crate::{FullGpSurrogate, GpSurrogate};
+use crate::{FullGpSurrogate, GpSurrogate, GpSurrogateExt};
 use bitflags::bitflags;
 #[allow(unused_imports)]
 use egobox_gp::correlation_models::{
@@ -122,6 +122,6 @@ impl Clustering {
 }
 
 /// A trait for Mixture of GP surrogates with derivatives using clustering
-pub trait MixtureGpSurrogate: Clustered + FullGpSurrogate {
-    fn experts(&self) -> &[Box<dyn FullGpSurrogate>];
+pub trait MixtureGpSurrogate: Clustered + GpSurrogate + GpSurrogateExt {
+    fn experts(&self) -> &Vec<Box<dyn FullGpSurrogate>>;
 }

--- a/python/egobox/tests/test_gpmix.py
+++ b/python/egobox/tests/test_gpmix.py
@@ -18,16 +18,20 @@ class TestGpMix(unittest.TestCase):
     def test_gpx_kriging(self):
         gpx = self.gpx
 
+        print(f"gpx.theta = {gpx.thetas()}")
+        print(f"gpx.variance= {gpx.variances()}")
+        print(f"gpx.likelihood = {gpx.likelihoods()}")
+
         # should interpolate
-        self.assertAlmostEqual(1.0, float(gpx.predict_values(np.array([[1.0]]))))
-        self.assertAlmostEqual(0.0, float(gpx.predict_variances(np.array([[1.0]]))))
+        self.assertAlmostEqual(1.0, gpx.predict_values(np.array([[1.0]])).item())
+        self.assertAlmostEqual(0.0, gpx.predict_variances(np.array([[1.0]])).item())
 
         # check a point not too far from a training point
         self.assertAlmostEqual(
-            1.1163, float(gpx.predict_values(np.array([[1.1]]))), delta=1e-3
+            1.1163, gpx.predict_values(np.array([[1.1]])).item(), delta=1e-3
         )
         self.assertAlmostEqual(
-            0.0, float(gpx.predict_variances(np.array([[1.1]]))), delta=1e-3
+            0.0, gpx.predict_variances(np.array([[1.1]])).item(), delta=1e-3
         )
 
     def test_gpx_save_load(self):
@@ -42,15 +46,15 @@ class TestGpMix(unittest.TestCase):
         os.remove(filename)
 
         # should interpolate
-        self.assertAlmostEqual(1.0, float(gpx2.predict_values(np.array([[1.0]]))))
-        self.assertAlmostEqual(0.0, float(gpx2.predict_variances(np.array([[1.0]]))))
+        self.assertAlmostEqual(1.0, gpx2.predict_values(np.array([[1.0]])).item())
+        self.assertAlmostEqual(0.0, gpx2.predict_variances(np.array([[1.0]])).item())
 
         # check a point not too far from a training point
         self.assertAlmostEqual(
-            1.1163, float(gpx2.predict_values(np.array([[1.1]]))), delta=1e-3
+            1.1163, gpx2.predict_values(np.array([[1.1]])).item(), delta=1e-3
         )
         self.assertAlmostEqual(
-            0.0, float(gpx2.predict_variances(np.array([[1.1]]))), delta=1e-3
+            0.0, gpx2.predict_variances(np.array([[1.1]])).item(), delta=1e-3
         )
 
 


### PR DESCRIPTION
A `Gpx` mixture surrogate gives now access to hyperparameters `thetas`, `variances` and reduced `likelihood` value of the expert Gp surrogates resulting from the training process.
Some surrogate traits where refactored: 
* Add `GpSurrogateExt` trait to manage derivatives and sampling
* Add `GpParameterized` trait to manage optimized parameters
* `MixtureGpSurrogate` is not a `FullGpSurrogate` any more
* Add experts retrieval from `GpMixture`