### PR TITLE
Prepare release 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2021"
 description = "A toolbox for efficient global optimization"
@@ -31,10 +31,10 @@ persistent-moe = ["egobox-moe/persistent"]
 blas = ["ndarray/blas", "egobox-gp/blas", "egobox-moe/blas", "egobox-ego/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.17.0", path = "./doe" }
-egobox-gp = { version = "0.17.0", path = "./gp" }
-egobox-moe = { version = "0.17.0", path = "./moe", features = ["persistent"] }
-egobox-ego = { version = "0.17.0", path = "./ego", features = ["persistent"] }
+egobox-doe = { version = "0.18.0", path = "./doe" }
+egobox-gp = { version = "0.18.0", path = "./gp" }
+egobox-moe = { version = "0.18.0", path = "./moe", features = ["persistent"] }
+egobox-ego = { version = "0.18.0", path = "./ego", features = ["persistent"] }
 
 linfa = { version = "0.7", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Depending on the sub-packages you want to use, you have to add following declara
 
 ```text
 [dependencies]
-egobox-doe = { version = "0.17" }
-egobox-gp  = { version = "0.17" }
-egobox-moe = { version = "0.17" }
-egobox-ego = { version = "0.17" }
+egobox-doe = { version = "0.18" }
+egobox-gp  = { version = "0.18" }
+egobox-moe = { version = "0.18" }
+egobox-ego = { version = "0.18" }
 ```
 
 ### Features
@@ -54,7 +54,7 @@ The table below presents the various features available depending on the subcrat
 | Name         | doe  | gp   | moe  | ego  |
 | :----------- | :--- | :--- | :--- | :--- |
 | serializable | ✔️    | ✔️    | ✔️    |      |
-| persistent   |      |      | ✔️    |  ✔️(*)  |
+| persistent   |      |      | ✔️    | ✔️(*) |
 | blas         |      | ✔️    | ✔️    | ✔️    |
 | nlopt        |      | ✔️    |      | ✔️    |
 
@@ -108,7 +108,7 @@ Thus, for instance, to use `gp` with the Intel MKL BLAS/LAPACK backend, you coul
 
 ```text
 [dependencies]
-egobox-gp = { version = "0.17", features = ["blas", "linfa/intel-mkl-static"] }
+egobox-gp = { version = "0.18", features = ["blas", "linfa/intel-mkl-static"] }
 ```
 
 or you could run the `gp` example as follows:

--- a/doe/Cargo.toml
+++ b/doe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-doe"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2021"
 description = "A library for design of experiments"

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-ego"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2021"
 description = "A library for efficient global optimization"
@@ -16,11 +16,11 @@ persistent = ["egobox-moe/persistent"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.17.0", path = "../doe", features = [
+egobox-doe = { version = "0.18.0", path = "../doe", features = [
     "serializable",
 ] }
-egobox-gp = { version = "0.17.0", path = "../gp", features = ["serializable"] }
-egobox-moe = { version = "0.17.0", path = "../moe", features = [
+egobox-gp = { version = "0.18.0", path = "../gp", features = ["serializable"] }
+egobox-moe = { version = "0.18.0", path = "../moe", features = [
     "serializable",
 ] }
 

--- a/gp/Cargo.toml
+++ b/gp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-gp"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2021"
 description = "A library for gaussian process modeling"
@@ -18,7 +18,7 @@ persistent = ["serializable", "serde_json"]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.17.0", path = "../doe" }
+egobox-doe = { version = "0.18.0", path = "../doe" }
 
 linfa = { version = "0.7", default-features = false }
 linfa-pls = { version = "0.7", default-features = false }

--- a/moe/Cargo.toml
+++ b/moe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egobox-moe"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 edition = "2021"
 description = "A library for mixture of expert gaussian processes"
@@ -29,8 +29,8 @@ serializable = [
 blas = ["ndarray-linalg", "linfa/ndarray-linalg", "linfa-pls/blas"]
 
 [dependencies]
-egobox-doe = { version = "0.17.0", path = "../doe" }
-egobox-gp = { version = "0.17.0", path = "../gp" }
+egobox-doe = { version = "0.18.0", path = "../doe" }
+egobox-gp = { version = "0.18.0", path = "../gp" }
 
 linfa = { version = "0.7", default-features = false }
 linfa-clustering = { version = "0.7", default-features = false }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python-source = "python"
 
 [tool.poetry]
 name = "egobox"
-version = "0.17.0"
+version = "0.18.0"
 description = "Python binding for egobox EGO optimizer written in Rust"
 authors = ["Rémi Lafage <remi.lafage@onera.fr>"]
 packages = [{ include = "egobox", from = "python" }]

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -66,14 +66,7 @@ def six_humps(x):
     x1 = x[:, 0]
     x2 = x[:, 1]
     print(x)
-    sum1 = (
-        4 * x1**2
-        - 2.1 * x1**4
-        + 1.0 / 3.0 * x1**6
-        + x1 * x2
-        - 4 * x2**2
-        + 4 * x2**4
-    )
+    sum1 = 4 * x1**2 - 2.1 * x1**4 + 1.0 / 3.0 * x1**6 + x1 * x2 - 4 * x2**2 + 4 * x2**4
     print(np.atleast_2d(sum1).T)
     return np.atleast_2d(sum1).T
 
@@ -142,7 +135,7 @@ class TestOptimizer(unittest.TestCase):
         egor = egx.Egor(
             egx.to_specs([[0.0, 3.0], [0.0, 4.0]]),
             n_cstr=2,
-            cstr_tol=np.array([1e-3, 1e-3]),
+            cstr_tol=np.array([5e-3, 5e-3]),
             regr_spec=egx.RegressionSpec.CONSTANT,
             corr_spec=egx.CorrelationSpec.SQUARED_EXPONENTIAL,
             kpls_dim=1,


### PR DESCRIPTION
Bump version after renaming `predict_derivatives` as `predict_gradients`