### PR TITLE
[EGO] Allow to reuse surrogate trainings (reuse previous hyperparameters) from a previous iteration

### DIFF
--- a/ego/src/egor.rs
+++ b/ego/src/egor.rs
@@ -303,6 +303,18 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_xsinx_optmod_egor() {
+        let res = EgorBuilder::optimize(xsinx)
+            .configure(|config| config.max_iters(20).n_optmod(3))
+            .min_within(&array![[0.0, 25.0]])
+            .run()
+            .expect("Egor should minimize");
+        let expected = array![18.9];
+        assert_abs_diff_eq!(expected, res.x_opt, epsilon = 1e-1);
+    }
+
+    #[test]
+    #[serial]
     fn test_xsinx_auto_clustering_egor_builder() {
         let res = EgorBuilder::optimize(xsinx)
             .configure(|config| config.n_clusters(0).max_iters(20))

--- a/ego/src/egor_config.rs
+++ b/ego/src/egor_config.rs
@@ -17,6 +17,9 @@ pub struct EgorConfig {
     pub(crate) max_iters: usize,
     /// Number of starts for multistart approach used for hyperparameters optimization
     pub(crate) n_start: usize,
+    /// Interval between two hyperparameters optimizations (as iteration number modulo)
+    /// hyperparameters are optimized or re-used from an iteration to another
+    pub(crate) n_optmod: usize,
     /// Number of points returned by EGO iteration (aka qEI Multipoint strategy)
     /// Actually as some point determination may fail (at most q_points are returned)
     pub(crate) q_points: usize,
@@ -64,6 +67,7 @@ impl Default for EgorConfig {
         EgorConfig {
             max_iters: 20,
             n_start: 20,
+            n_optmod: 1,
             q_points: 1,
             n_doe: 0,
             n_cstr: 0,
@@ -100,6 +104,12 @@ impl EgorConfig {
     /// Sets the number of runs of infill strategy optimizations (best result taken)
     pub fn n_start(mut self, n_start: usize) -> Self {
         self.n_start = n_start;
+        self
+    }
+
+    /// Sets the number of iteration interval between two hyperparameter optimization
+    pub fn n_optmod(mut self, n_optmod: usize) -> Self {
+        self.n_optmod = n_optmod;
         self
     }
 

--- a/ego/src/egor_solver.rs
+++ b/ego/src/egor_solver.rs
@@ -576,7 +576,7 @@ where
         builder.set_n_clusters(self.config.n_clusters);
 
         if init || recluster {
-            println!("i={iter} RECLUST THETA OPTIM");
+            debug!("i={iter} RECLUST THETA OPTIM");
             if recluster {
                 info!("{} reclustering and training...", model_name);
             } else {
@@ -597,7 +597,7 @@ where
 
             let theta_tunings = if iter % (self.config.n_optmod as u64) == 0 {
                 // set hyperparameters optimization
-                println!("i={iter} THETA OPTIM");
+                debug!("i={iter} THETA OPTIM");
                 theta_inits
                     .unwrap()
                     .outer_iter()
@@ -608,7 +608,7 @@ where
                     .collect::<Vec<_>>()
             } else {
                 // just use previous hyperparameters
-                println!("i={iter} THETA REUSED");
+                debug!("i={iter} THETA REUSED");
                 theta_inits
                     .unwrap()
                     .outer_iter()

--- a/ego/src/mixint.rs
+++ b/ego/src/mixint.rs
@@ -5,6 +5,7 @@
 use crate::errors::{EgoError, Result};
 use crate::types::{SurrogateBuilder, XType};
 use egobox_doe::{FullFactorial, Lhs, LhsKind, Random};
+use egobox_gp::ThetaTuning;
 use egobox_moe::{
     Clustered, Clustering, CorrelationSpec, FullGpSurrogate, GpMixture, GpMixtureParams,
     GpSurrogate, GpSurrogateExt, MixtureGpSurrogate, RegressionSpec,
@@ -431,6 +432,19 @@ impl SurrogateBuilder for MixintGpMixtureParams {
     fn set_n_clusters(&mut self, n_clusters: usize) {
         self.0 = MixintMoeValidParams {
             surrogate_builder: self.0.surrogate_builder.clone().n_clusters(n_clusters),
+            xtypes: self.0.xtypes.clone(),
+            work_in_folded_space: self.0.work_in_folded_space,
+        }
+    }
+
+    /// Sets the theta hyperparameter tuning strategy
+    fn set_theta_tunings(&mut self, theta_tunings: &[ThetaTuning<f64>]) {
+        self.0 = MixintMoeValidParams {
+            surrogate_builder: self
+                .0
+                .surrogate_builder
+                .clone()
+                .theta_tunings(theta_tunings),
             xtypes: self.0.xtypes.clone(),
             work_in_folded_space: self.0.work_in_folded_space,
         }

--- a/ego/src/types.rs
+++ b/ego/src/types.rs
@@ -1,6 +1,6 @@
 use crate::errors::Result;
 use argmin::core::CostFunction;
-use egobox_moe::{Clustering, MixtureGpSurrogate};
+use egobox_moe::{Clustering, MixtureGpSurrogate, ThetaTuning};
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView2};
 use serde::{Deserialize, Serialize};
@@ -122,6 +122,9 @@ pub trait SurrogateBuilder: Clone + Serialize + Sync {
 
     /// Sets the number of clusters used by the mixture of surrogate experts.
     fn set_n_clusters(&mut self, n_clusters: usize);
+
+    /// Sets the hyperparameters tuning strategy
+    fn set_theta_tunings(&mut self, theta_tunings: &[ThetaTuning<f64>]);
 
     /// Train the surrogate with given training dataset (x, y)
     fn train(

--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -692,7 +692,7 @@ where
 }
 
 /// Gausssian Process adaptator to implement `linfa::Predict` trait for variance prediction.
-struct GpVariancePredictor<'a, F, Mean, Corr>(&'a GaussianProcess<F, Mean, Corr>)
+pub struct GpVariancePredictor<'a, F, Mean, Corr>(&'a GaussianProcess<F, Mean, Corr>)
 where
     F: Float,
     Mean: RegressionModel<F>,

--- a/gp/src/parameters.rs
+++ b/gp/src/parameters.rs
@@ -19,7 +19,7 @@ pub enum ThetaTuning<F: Float> {
 impl<F: Float> Default for ThetaTuning<F> {
     fn default() -> Self {
         ThetaTuning::Optimized {
-            init: vec![F::cast(0.01)],
+            init: vec![F::cast(ThetaTuning::<F>::DEFAULT_INIT)],
             bounds: vec![(
                 F::cast(ThetaTuning::<F>::DEFAULT_BOUNDS.0),
                 F::cast(ThetaTuning::<F>::DEFAULT_BOUNDS.1),
@@ -29,6 +29,7 @@ impl<F: Float> Default for ThetaTuning<F> {
 }
 
 impl<F: Float> ThetaTuning<F> {
+    pub const DEFAULT_INIT: f64 = 1e-2;
     pub const DEFAULT_BOUNDS: (f64, f64) = (1e-6, 1e2);
 
     pub fn init(&self) -> &Vec<F> {

--- a/gp/src/sparse_algorithm.rs
+++ b/gp/src/sparse_algorithm.rs
@@ -378,14 +378,14 @@ where
     }
 }
 
-/// Gausssian Process adaptator to implement `linfa::Predict` trait for variance prediction.
-struct GpVariancePredictor<'a, F, Corr>(&'a SparseGaussianProcess<F, Corr>)
+/// Sparse Gausssian Process adaptator to implement `linfa::Predict` trait for variance prediction.
+pub struct SparseGpVariancePredictor<'a, F, Corr>(&'a SparseGaussianProcess<F, Corr>)
 where
     F: Float,
     Corr: CorrelationModel<F>;
 
 impl<'a, F, D, Corr> PredictInplace<ArrayBase<D, Ix2>, Array2<F>>
-    for GpVariancePredictor<'a, F, Corr>
+    for SparseGpVariancePredictor<'a, F, Corr>
 where
     F: Float,
     D: Data<Elem = F>,

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -52,7 +52,7 @@ def G24_c2(point):
 def g24(point):
     p = np.atleast_2d(point)
     res = np.array([G24(p), G24_c1(p), G24_c2(p)]).T
-    print(res)
+    print(f"y={res}")
     return res
 
 
@@ -65,9 +65,9 @@ def six_humps(x):
     x = np.atleast_2d(x)
     x1 = x[:, 0]
     x2 = x[:, 1]
-    print(x)
+    print(f"x={x}")
     sum1 = 4 * x1**2 - 2.1 * x1**4 + 1.0 / 3.0 * x1**6 + x1 * x2 - 4 * x2**2 + 4 * x2**4
-    print(np.atleast_2d(sum1).T)
+    print(f"y={np.atleast_2d(sum1).T}")
     return np.atleast_2d(sum1).T
 
 
@@ -142,7 +142,7 @@ class TestOptimizer(unittest.TestCase):
             seed=1,
         )
         start = time.process_time()
-        res = egor.minimize(g24, max_iters=20)
+        res = egor.minimize(g24, max_iters=30)
         end = time.process_time()
         self.assertAlmostEqual(-5.5080, res.y_opt[0], delta=5e-1)
         print(f"Optimization f={res.y_opt} at {res.x_opt} in {end-start}s")

--- a/src/gp_mix.rs
+++ b/src/gp_mix.rs
@@ -152,6 +152,7 @@ impl GpMix {
                 bounds: bounds.iter().map(|v| (v[0], v[1])).collect(),
             }
         }
+        let theta_tunings = vec![theta_tuning; self.n_clusters];
 
         if let Err(ctrlc::Error::MultipleHandlers) = ctrlc::set_handler(|| std::process::exit(2)) {
             // ignore multiple handlers error
@@ -166,7 +167,7 @@ impl GpMix {
                 .correlation_spec(
                     egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
                 )
-                .theta_tuning(theta_tuning)
+                .theta_tunings(&theta_tunings)
                 .kpls_dim(self.kpls_dim)
                 .n_start(self.n_start)
                 .with_rng(rng)

--- a/src/sparse_gp_mix.rs
+++ b/src/sparse_gp_mix.rs
@@ -156,6 +156,7 @@ impl SparseGpMix {
                 bounds: bounds.iter().map(|v| (v[0], v[1])).collect(),
             }
         }
+        let theta_tunings = vec![theta_tuning];
 
         if let Err(ctrlc::Error::MultipleHandlers) = ctrlc::set_handler(|| std::process::exit(2)) {
             // ignore multiple handlers error
@@ -169,7 +170,7 @@ impl SparseGpMix {
                 .correlation_spec(
                     egobox_moe::CorrelationSpec::from_bits(self.correlation_spec.0).unwrap(),
                 )
-                .theta_tuning(theta_tuning)
+                .theta_tunings(&theta_tunings)
                 .kpls_dim(self.kpls_dim)
                 .n_start(self.n_start)
                 .with_rng(rng)


### PR DESCRIPTION
This PR leverages on #155 allowing to specify a rate of optimization for theta hyperparameters vi `n_optmod` option (1 means always, 2 means one out of 2, 3 means one out of 3, etc.). 