### PR TITLE
Save iteration number

### DIFF
--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -87,8 +87,6 @@ class TestOptimizer(unittest.TestCase):
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-3)
 
     def test_xsinx_with_hotstart(self):
-        if os.path.exists("./test_dir/egor_initial_doe.npy"):
-            os.remove("./test_dir/egor_initial_doe.npy")
         if os.path.exists("./test_dir/egor_doe.npy"):
             os.remove("./test_dir/egor_doe.npy")
         xlimits = egx.to_specs([[0.0, 25.0]])
@@ -105,8 +103,6 @@ class TestOptimizer(unittest.TestCase):
         self.assertAlmostEqual(-15.125, res.y_opt[0], delta=1e-2)
         self.assertAlmostEqual(18.935, res.x_opt[0], delta=1e-2)
 
-        self.assertTrue(os.path.exists("./test_dir/egor_initial_doe.npy"))
-        os.remove("./test_dir/egor_initial_doe.npy")
         self.assertTrue(os.path.exists("./test_dir/egor_doe.npy"))
         os.remove("./test_dir/egor_doe.npy")
 


### PR DESCRIPTION
The DOE_INITIAL_FILE is removed as the initial doe points are specified with an iteration number set to 0.
The .npy DOE file format has rows like : `n_iter, x, y` where `y` is `obj, cstr1, ..., cstr_n`.
Fixes #186 