### PR TITLE
Save config and optim history

### DIFF
--- a/ego/src/solver/egor_solver.rs
+++ b/ego/src/solver/egor_solver.rs
@@ -125,7 +125,7 @@ use std::time::Instant;
 
 /// Numpy filename for initial DOE dump
 pub const DOE_INITIAL_FILE: &str = "egor_initial_doe.npy";
-/// Numpy Filename for current DOE dump
+/// Numpy filename for current DOE dump
 pub const DOE_FILE: &str = "egor_doe.npy";
 
 /// Default tolerance value for constraints to be satisfied (ie cstr < tol)


### PR DESCRIPTION
This PR saves the config used by the solver and the optimization history for subsequent analysis.
The following files are saved only if `outdir` potion is set
* `egor_config.json`: `EgorConfig` srtucture seriallized as json
* `egor_history`: numpy 2d-array each row being [obj, cstrs, params] value at a given iteration (row index)