### PR TITLE
Add checkpointing and hot start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ input.txt
 output.txt
 mopta08.exe
 mopta08_elf64.bin
+**/.checkpoints
 
 # JOSS
 joss/paper.jats
 joss/paper.pdf
+

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -41,6 +41,7 @@ nlopt = { version = "0.7.0", optional = true }
 
 rand_xoshiro = { version = "0.6", features = ["serde1"] }
 argmin = { version = "0.10.0", features = ["serde1", "ctrlc"] }
+argmin-checkpointing-file = { version = "0.1.0" }
 web-time = "1.1.0"
 libm = "0.2.6"
 finitediff = { version = "0.1", features = ["ndarray"] }

--- a/ego/Cargo.toml
+++ b/ego/Cargo.toml
@@ -41,7 +41,7 @@ nlopt = { version = "0.7.0", optional = true }
 
 rand_xoshiro = { version = "0.6", features = ["serde1"] }
 argmin = { version = "0.10.0", features = ["serde1", "ctrlc"] }
-argmin-checkpointing-file = { version = "0.1.0" }
+bincode = { version = "1.3.0" }
 web-time = "1.1.0"
 libm = "0.2.6"
 finitediff = { version = "0.1", features = ["ndarray"] }

--- a/ego/src/lib.rs
+++ b/ego/src/lib.rs
@@ -209,7 +209,9 @@ pub use crate::errors::*;
 pub use crate::gpmix::spec::{CorrelationSpec, RegressionSpec};
 pub use crate::solver::*;
 pub use crate::types::*;
-pub use crate::utils::find_best_result_index;
+pub use crate::utils::{
+    find_best_result_index, Checkpoint, CheckpointingFrequency, HotStartCheckpoint,
+};
 
 mod optimizers;
 mod utils;

--- a/ego/src/solver/egor_config.rs
+++ b/ego/src/solver/egor_config.rs
@@ -21,7 +21,7 @@ pub(crate) struct TregoConfig {
 impl Default for TregoConfig {
     fn default() -> Self {
         TregoConfig {
-            activated: false,
+            activated: true,
             n_local_steps: 4,
             d: (1e-6, 1.),
             beta: 0.9,

--- a/ego/src/solver/egor_config.rs
+++ b/ego/src/solver/egor_config.rs
@@ -80,6 +80,8 @@ pub struct EgorConfig {
     pub(crate) outdir: Option<String>,
     /// If true use `outdir` to retrieve and start from previous results
     pub(crate) warm_start: bool,
+    /// If true enable checkpointing allowing to restart from last checkpointed iteration
+    pub(crate) hot_start: bool,
     /// List of x types allowing the handling of discrete input variables
     pub(crate) xtypes: Vec<XType>,
     /// A random generator seed used to get reproductible results.
@@ -109,6 +111,7 @@ impl Default for EgorConfig {
             target: f64::NEG_INFINITY,
             outdir: None,
             warm_start: false,
+            hot_start: false,
             xtypes: vec![],
             seed: None,
             trego: TregoConfig::default(),
@@ -262,6 +265,12 @@ impl EgorConfig {
     /// Whether we start by loading last DOE saved in `outdir` as initial DOE
     pub fn warm_start(mut self, warm_start: bool) -> Self {
         self.warm_start = warm_start;
+        self
+    }
+
+    /// Whether checkpointing is enabled allowing hot start from previous checkpointed iteration if any
+    pub fn hot_start(mut self, hot_start: bool) -> Self {
+        self.hot_start = hot_start;
         self
     }
 

--- a/ego/src/solver/egor_config.rs
+++ b/ego/src/solver/egor_config.rs
@@ -21,7 +21,7 @@ pub(crate) struct TregoConfig {
 impl Default for TregoConfig {
     fn default() -> Self {
         TregoConfig {
-            activated: true,
+            activated: false,
             n_local_steps: 4,
             d: (1e-6, 1.),
             beta: 0.9,
@@ -80,8 +80,8 @@ pub struct EgorConfig {
     pub(crate) outdir: Option<String>,
     /// If true use `outdir` to retrieve and start from previous results
     pub(crate) warm_start: bool,
-    /// If true enable checkpointing allowing to restart from last checkpointed iteration
-    pub(crate) hot_start: bool,
+    /// If some enable checkpointing allowing to restart for given ext_iters number of iteration from last checkpointed iteration
+    pub(crate) hot_start: Option<u64>,
     /// List of x types allowing the handling of discrete input variables
     pub(crate) xtypes: Vec<XType>,
     /// A random generator seed used to get reproductible results.
@@ -111,7 +111,7 @@ impl Default for EgorConfig {
             target: f64::NEG_INFINITY,
             outdir: None,
             warm_start: false,
-            hot_start: false,
+            hot_start: None,
             xtypes: vec![],
             seed: None,
             trego: TregoConfig::default(),
@@ -269,7 +269,7 @@ impl EgorConfig {
     }
 
     /// Whether checkpointing is enabled allowing hot start from previous checkpointed iteration if any
-    pub fn hot_start(mut self, hot_start: bool) -> Self {
+    pub fn hot_start(mut self, hot_start: Option<u64>) -> Self {
         self.hot_start = hot_start;
         self
     }

--- a/ego/src/solver/egor_impl.rs
+++ b/ego/src/solver/egor_impl.rs
@@ -22,8 +22,9 @@ use ndarray::{
 use ndarray_stats::QuantileExt;
 use rand_xoshiro::Xoshiro256Plus;
 use rayon::prelude::*;
+use serde::de::DeserializeOwned;
 
-impl<SB: SurrogateBuilder> EgorSolver<SB> {
+impl<SB: SurrogateBuilder + DeserializeOwned> EgorSolver<SB> {
     /// Constructor of the optimization of the function `f` with specified random generator
     /// to get reproducibility.
     ///
@@ -80,7 +81,7 @@ impl<SB: SurrogateBuilder> EgorSolver<SB> {
 
 impl<SB> EgorSolver<SB>
 where
-    SB: SurrogateBuilder,
+    SB: SurrogateBuilder + DeserializeOwned,
 {
     pub fn have_to_recluster(&self, added: usize, prev_added: usize) -> bool {
         self.config.n_clusters == 0 && (added != 0 && added % 10 == 0 && added - prev_added > 0)

--- a/ego/src/solver/egor_service.rs
+++ b/ego/src/solver/egor_service.rs
@@ -46,6 +46,7 @@ use egobox_moe::GpMixtureParams;
 use ndarray::{Array2, ArrayBase, Data, Ix2};
 use ndarray_rand::rand::SeedableRng;
 use rand_xoshiro::Xoshiro256Plus;
+use serde::de::DeserializeOwned;
 
 /// EGO optimizer service builder allowing to use Egor optimizer
 /// as a service.
@@ -114,11 +115,11 @@ impl EgorServiceBuilder {
 
 /// Egor optimizer service.
 #[derive(Clone)]
-pub struct EgorService<SB: SurrogateBuilder> {
+pub struct EgorService<SB: SurrogateBuilder + DeserializeOwned> {
     solver: EgorSolver<SB>,
 }
 
-impl<SB: SurrogateBuilder> EgorService<SB> {
+impl<SB: SurrogateBuilder + DeserializeOwned> EgorService<SB> {
     /// Given an evaluated doe (x, y) data, return the next promising x point
     /// where optimum may be located with regard to the infill criterion.
     /// This function inverses the control of the optimization and can be used

--- a/ego/src/solver/egor_solver.rs
+++ b/ego/src/solver/egor_solver.rs
@@ -120,7 +120,7 @@ use argmin::core::{
 };
 
 use rand_xoshiro::Xoshiro256Plus;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::time::Instant;
 
 /// Numpy filename for initial DOE dump
@@ -161,7 +161,7 @@ pub fn to_xtypes(xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>) -> Vec<XType> 
 impl<O, SB> Solver<O, EgorState<f64>> for EgorSolver<SB>
 where
     O: CostFunction<Param = Array2<f64>, Output = Array2<f64>>,
-    SB: SurrogateBuilder,
+    SB: SurrogateBuilder + DeserializeOwned,
 {
     const NAME: &'static str = "Egor";
 
@@ -304,7 +304,7 @@ where
 
 impl<SB> EgorSolver<SB>
 where
-    SB: SurrogateBuilder,
+    SB: SurrogateBuilder + DeserializeOwned,
 {
     /// Iteration of EGO algorithm
     fn ego_iteration<O: CostFunction<Param = Array2<f64>, Output = Array2<f64>>>(

--- a/ego/src/solver/egor_state.rs
+++ b/ego/src/solver/egor_state.rs
@@ -289,6 +289,16 @@ where
     }
 }
 
+impl<F> EgorState<F>
+where
+    F: Float + ArgminFloat,
+{
+    /// Allow hot start feature by extending current max_iters
+    pub fn extend_max_iters(&mut self, ext_iters: u64) {
+        self.max_iters += ext_iters;
+    }
+}
+
 impl<F> State for EgorState<F>
 where
     F: Float + ArgminFloat,

--- a/ego/src/solver/trego.rs
+++ b/ego/src/solver/trego.rs
@@ -21,8 +21,9 @@ use ndarray::Zip;
 use ndarray::{s, Array, Array1, Array2, ArrayView1, Axis};
 
 use rayon::prelude::*;
+use serde::de::DeserializeOwned;
 
-impl<SB: SurrogateBuilder> EgorSolver<SB> {
+impl<SB: SurrogateBuilder + DeserializeOwned> EgorSolver<SB> {
     /// Local step where infill criterion is optimized within trust region
     pub fn trego_step<O: CostFunction<Param = Array2<f64>, Output = Array2<f64>>>(
         &mut self,

--- a/ego/src/utils/hot_start.rs
+++ b/ego/src/utils/hot_start.rs
@@ -1,0 +1,94 @@
+pub use argmin::core::checkpointing::{Checkpoint, CheckpointingFrequency};
+use argmin::core::Error;
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::PathBuf;
+
+use crate::EgorState;
+
+/// Handles saving a checkpoint to disk as a binary file.
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+pub struct HotStartCheckpoint {
+    /// Extended iteration number
+    pub extension_iters: u64,
+    /// Indicates how often a checkpoint is created
+    pub frequency: CheckpointingFrequency,
+    /// Directory where the checkpoints are saved to
+    pub directory: PathBuf,
+    /// Name of the checkpoint files
+    pub filename: PathBuf,
+}
+
+impl Default for HotStartCheckpoint {
+    /// Create a default `HotStartCheckpoint` instance.
+    fn default() -> HotStartCheckpoint {
+        HotStartCheckpoint {
+            extension_iters: 0,
+            frequency: CheckpointingFrequency::default(),
+            directory: PathBuf::from(".checkpoints"),
+            filename: PathBuf::from("egor.arg"),
+        }
+    }
+}
+
+impl HotStartCheckpoint {
+    /// Create a new `HotStartCheckpoint` instance
+    pub fn new<N: AsRef<str>>(
+        directory: N,
+        name: N,
+        frequency: CheckpointingFrequency,
+        ext_iters: u64,
+    ) -> Self {
+        HotStartCheckpoint {
+            extension_iters: ext_iters,
+            frequency,
+            directory: PathBuf::from(directory.as_ref()),
+            filename: PathBuf::from(format!("{}.arg", name.as_ref())),
+        }
+    }
+}
+
+impl<S> Checkpoint<S, EgorState<f64>> for HotStartCheckpoint
+where
+    S: Serialize + DeserializeOwned,
+{
+    /// Writes checkpoint to disk.
+    ///
+    /// If the directory does not exist already, it will be created. It uses `bincode` to serialize
+    /// the data.
+    /// It will return an error if creating the directory or file or serialization failed.
+    fn save(&self, solver: &S, state: &EgorState<f64>) -> Result<(), Error> {
+        if !self.directory.exists() {
+            std::fs::create_dir_all(&self.directory)?
+        }
+        let fname = self.directory.join(&self.filename);
+        let f = BufWriter::new(File::create(fname)?);
+        bincode::serialize_into(f, &(solver, state))?;
+        Ok(())
+    }
+
+    /// Load a checkpoint from disk.
+    ///
+    ///
+    /// If there is no checkpoint on disk, it will return `Ok(None)`.
+    /// Returns an error if opening the file or deserialization failed.
+    fn load(&self) -> Result<Option<(S, EgorState<f64>)>, Error> {
+        let path = &self.directory.join(&self.filename);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        let (solver, mut state): (_, EgorState<_>) = bincode::deserialize_from(reader)?;
+        state.extend_max_iters(self.extension_iters);
+        Ok(Some((solver, state)))
+    }
+
+    /// Returns the how often a checkpoint is to be saved.
+    ///
+    /// Used internally by [`save_cond`](`argmin::core::checkpointing::Checkpoint::save_cond`).
+    fn frequency(&self) -> CheckpointingFrequency {
+        self.frequency
+    }
+}

--- a/ego/src/utils/mod.rs
+++ b/ego/src/utils/mod.rs
@@ -1,6 +1,8 @@
 mod find_result;
+mod hot_start;
 mod misc;
 mod sort_axis;
 
 pub use find_result::*;
+pub use hot_start::*;
 pub use misc::*;

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -138,9 +138,10 @@ pub(crate) fn to_specs(py: Python, xlimits: Vec<Vec<f64>>) -> PyResult<PyObject>
 ///     warm_start (bool)
 ///         Start by loading initial doe from <outdir> directory
 ///
-///     hot_start (bool)
-///         Start from last checkpoint if any and save optimizer state at each iteration allowing further hot start
-///         Checkpoint information is stored in .checkpoint directory
+///     hot_start (u64 or None)
+///         Start from last checkpoint if any for a given number of iterations beyond initial max_iters
+///         and save optimizer state at each iteration allowing further hot start
+///         Checkpoint information is stored in .checkpoint directory.
 ///
 ///     seed (int >= 0)
 ///         Random generator seed to allow computation reproducibility.
@@ -166,7 +167,7 @@ pub(crate) struct Egor {
     pub target: f64,
     pub outdir: Option<String>,
     pub warm_start: bool,
-    pub hot_start: bool,
+    pub hot_start: Option<u64>,
     pub seed: Option<u64>,
 }
 
@@ -205,7 +206,7 @@ impl Egor {
         target = f64::NEG_INFINITY,
         outdir = None,
         warm_start = false,
-        hot_start = false,
+        hot_start = None,
         seed = None
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -230,7 +231,7 @@ impl Egor {
         target: f64,
         outdir: Option<String>,
         warm_start: bool,
-        hot_start: bool,
+        hot_start: Option<u64>,
         seed: Option<u64>,
     ) -> Self {
         let doe = doe.map(|x| x.to_owned_array());

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -138,6 +138,10 @@ pub(crate) fn to_specs(py: Python, xlimits: Vec<Vec<f64>>) -> PyResult<PyObject>
 ///     warm_start (bool)
 ///         Start by loading initial doe from <outdir> directory
 ///
+///     hot_start (bool)
+///         Start from last checkpoint if any and save optimizer state at each iteration allowing further hot start
+///         Checkpoint information is stored in .checkpoint directory
+///
 ///     seed (int >= 0)
 ///         Random generator seed to allow computation reproducibility.
 ///      
@@ -162,6 +166,7 @@ pub(crate) struct Egor {
     pub target: f64,
     pub outdir: Option<String>,
     pub warm_start: bool,
+    pub hot_start: bool,
     pub seed: Option<u64>,
 }
 
@@ -200,6 +205,7 @@ impl Egor {
         target = f64::NEG_INFINITY,
         outdir = None,
         warm_start = false,
+        hot_start = false,
         seed = None
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -224,6 +230,7 @@ impl Egor {
         target: f64,
         outdir: Option<String>,
         warm_start: bool,
+        hot_start: bool,
         seed: Option<u64>,
     ) -> Self {
         let doe = doe.map(|x| x.to_owned_array());
@@ -247,6 +254,7 @@ impl Egor {
             target,
             outdir,
             warm_start,
+            hot_start,
             seed,
         }
     }
@@ -462,7 +470,8 @@ impl Egor {
             .trego(self.trego)
             .n_optmod(self.n_optmod)
             .target(self.target)
-            .warm_start(self.warm_start); // when used as a service no warmstart
+            .warm_start(self.warm_start)
+            .hot_start(self.hot_start);
         if let Some(doe) = doe {
             config = config.doe(doe);
         };

--- a/src/egor.rs
+++ b/src/egor.rs
@@ -138,10 +138,14 @@ pub(crate) fn to_specs(py: Python, xlimits: Vec<Vec<f64>>) -> PyResult<PyObject>
 ///     warm_start (bool)
 ///         Start by loading initial doe from <outdir> directory
 ///
-///     hot_start (u64 or None)
-///         Start from last checkpoint if any for a given number of iterations beyond initial max_iters
-///         and save optimizer state at each iteration allowing further hot start
-///         Checkpoint information is stored in .checkpoint directory.
+///     hot_start (int or None)
+///         When hot_start>=0 saves optimizer state at each iteration and starts from a previous checkpoint
+///         if any for the given hot_start number of iterations beyond the max_iters nb of iterations.
+///         In an unstable environment were there can be crashes it allows to restart the optimization
+///         from the last iteration till stopping criterion is reached. Just use hot_start=0 in this case.
+///         When specifying an extended nb of iterations (hot_start > 0) it can allow to continue till max_iters +
+///         hot_start nb of iters is reached (provided the stopping criterion is max_iters)
+///         Checkpoint information is stored in .checkpoint/egor.arg binary file.
 ///
 ///     seed (int >= 0)
 ///         Random generator seed to allow computation reproducibility.


### PR DESCRIPTION
This PR adds the ability to restart from previous saved iteration (checkpoint) either to complete to the max nb of iterations after an interruption or even to continue the optimization for an extended number of iterations after max_iters is reached.
This behaviour is controlled by the `hot_start` integer parameter which has to be set at least to 0 to enable the checkpointing and optionally set to n_iters > 0 to trigger n_iters iterations after `max_iters` is reached.