### PR TITLE
Update to numpy crate 0.22.1 to fix win32 compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf314fca279e6e6ac2126a4ff98f26d88aa4ad06bc68fb6ae5cf4bd706758311"
+checksum = "edb929bc0da91a4d85ed6c0a84deaa53d411abfb387fc271124f91bf6b89f14e"
 dependencies = [
  "libc",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = "0.4"
 
 pyo3 = { version = "0.22", features = ["extension-module"] }
 pyo3-log = "0.11"
-numpy = "0.22.0"
+numpy = "0.22.1"
 
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
Update to numpy crate 0.22.1 to fix win32 compilation