### PR TITLE
Panic if training output data is not one-dimensional

### DIFF
--- a/gp/src/algorithm.rs
+++ b/gp/src/algorithm.rs
@@ -734,6 +734,12 @@ impl<F: Float, Mean: RegressionModel<F>, Corr: CorrelationModel<F>, D: Data<Elem
     ) -> Result<Self::Object> {
         let x = dataset.records();
         let y = dataset.targets();
+        if y.ncols() > 1 {
+            panic!(
+                "Multiple outputs not handled, a one-dimensional column vector \
+            as training output data is expected"
+            );
+        }
         if let Some(d) = self.kpls_dim() {
             if *d > x.ncols() {
                 return Err(GpError::InvalidValueError(format!(
@@ -1558,6 +1564,19 @@ mod tests {
             .fit(&Dataset::new(xt, yt))
             .expect("GP fit error");
         assert_abs_diff_eq!(*gp.theta().to_vec(), expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_multiple_outputs() {
+        let xt = array![[0.0], [1.0], [2.0], [3.0], [4.0]];
+        let yt = array![[0.0, 10.0], [1.0, -3.], [1.5, 1.5], [0.9, 1.0], [1.0, 0.0]];
+        let _gp = Kriging::params()
+            .fit(&Dataset::new(xt.clone(), yt.clone()))
+            .expect("GP fit error");
+        // println!("theta = {}", gp.theta());
+        // let xtest = array![[0.1]];
+        // println!("pred({}) = {}", &xtest, gp.predict(&xtest).unwrap());
     }
 
     fn x2sinx(x: &Array2<f64>) -> Array2<f64> {

--- a/python/egobox/tests/test_gpmix.py
+++ b/python/egobox/tests/test_gpmix.py
@@ -119,6 +119,14 @@ class TestGpMix(unittest.TestCase):
             error = np.linalg.norm(y_pred - y_test) / np.linalg.norm(y_test)
             print("   RMS error: " + str(error))
 
+    def test_multi_outputs_exception(self):
+        self.xt = np.array([[0.0, 1.0, 2.0, 3.0, 4.0]]).T
+        self.yt = np.array(
+            [[0.0, 10.0], [1.0, -3.0], [1.5, 1.5], [0.9, 1.0], [1.0, 0.0]]
+        )
+        with self.assertRaises(BaseException):
+            egx.Gpx.builder().fit(self.xt, self.yt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/egobox/tests/test_sgpmix.py
+++ b/python/egobox/tests/test_sgpmix.py
@@ -60,6 +60,25 @@ class TestSgp(unittest.TestCase):
         print(elapsed)
         print(sgp)
 
+    def test_sgp_multi_outputs_exception(self):
+        # random generator for reproducibility
+        rng = np.random.RandomState(0)
+
+        # Generate training data
+        nt = 200
+        # Variance of the gaussian noise on our trainingg data
+        eta2 = [0.01]
+        gaussian_noise = rng.normal(loc=0.0, scale=np.sqrt(eta2), size=(nt, 1))
+        xt = 2 * rng.rand(nt, 1) - 1
+        yt = f_obj(xt) + gaussian_noise
+        yt = np.hstack((yt, yt))
+
+        # Pick inducing points randomly in training data
+        n_inducing = 30
+
+        with self.assertRaises(BaseException):
+            egx.SparseGpMix(nz=n_inducing, seed=0).fit(xt, yt)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The GaussianProcess/SparsegGaussianProcess current fit API accepts a training output being a 2D array but the model implementations actually handle only one dimensional output (ie training output has to be a column vector). 
Passing multiple output data leads to wrong predictors. 
As a short-term measure, to enforce this constraint, this PR adds the check of the training output dimension and panic if it is not a column vector.

This comes from original Python SMT API (see https://github.com/SMTorg/smt/issues/679) but actually should be revised in Rust. GP/SGP API should use an `Array1` as the type for training outputs (instead of an `Array2`). 

 