### PR TITLE
Relax number of points required wrt regression spec

### DIFF
--- a/crates/ego/examples/mopta08.rs
+++ b/crates/ego/examples/mopta08.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use egobox_ego::{EgorBuilder, GroupFunc, InfillOptimizer};
-use egobox_moe::{CorrelationSpec, RegressionSpec};
+use egobox_moe::{CorrelationSpec, NbClusters, RegressionSpec};
 use ndarray::{s, Array1, Array2, ArrayView1, ArrayView2};
 use std::fs::{remove_file, File};
 use std::io::prelude::*;
@@ -267,7 +267,7 @@ fn main() -> anyhow::Result<()> {
             config
                 .n_cstr(N_CSTR)
                 .cstr_tol(cstr_tol.clone())
-                .n_clusters(1)
+                .n_clusters(NbClusters::fixed(1))
                 .n_start(50)
                 .n_doe(n_doe)
                 .max_iters(max_iters)

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -361,6 +361,7 @@ mod tests {
     use approx::assert_abs_diff_eq;
     use argmin_testfunctions::rosenbrock;
     use egobox_doe::{Lhs, SamplingMethod};
+    use egobox_moe::NbClusters;
     use ndarray::{array, s, Array1, Array2, ArrayView2, Ix1, Zip};
 
     use ndarray_npy::read_npy;
@@ -513,7 +514,7 @@ mod tests {
     #[serial]
     fn test_xsinx_auto_clustering_egor_builder() {
         let res = EgorBuilder::optimize(xsinx)
-            .configure(|config| config.n_clusters(0).max_iters(20))
+            .configure(|config| config.n_clusters(NbClusters::auto()).max_iters(20))
             .min_within(&array![[0.0, 25.0]])
             .run()
             .expect("Egor with auto clustering should minimize xsinx");

--- a/crates/ego/src/gpmix/mixint.rs
+++ b/crates/ego/src/gpmix/mixint.rs
@@ -10,7 +10,7 @@ use egobox_gp::metrics::CrossValScore;
 use egobox_gp::ThetaTuning;
 use egobox_moe::{
     Clustered, Clustering, CorrelationSpec, FullGpSurrogate, GpMixture, GpMixtureParams,
-    GpSurrogate, GpSurrogateExt, MixtureGpSurrogate, RegressionSpec,
+    GpSurrogate, GpSurrogateExt, MixtureGpSurrogate, NbClusters, RegressionSpec,
 };
 use linfa::traits::{Fit, PredictInplace};
 use linfa::{DatasetBase, Float, ParamGuard};
@@ -358,8 +358,7 @@ impl MixintGpMixtureValidParams {
                 .surrogate_builder
                 .clone()
                 .check()?
-                .train(&xcast, &yt.to_owned())
-                .unwrap(),
+                .train(&xcast, &yt.to_owned())?,
             xtypes: self.xtypes.clone(),
             work_in_folded_space: self.work_in_folded_space,
             training_data: (xt.to_owned(), yt.to_owned()),
@@ -437,7 +436,7 @@ impl SurrogateBuilder for MixintGpMixtureParams {
     }
 
     /// Sets the number of clusters used by the mixture of surrogate experts.
-    fn set_n_clusters(&mut self, n_clusters: usize) {
+    fn set_n_clusters(&mut self, n_clusters: NbClusters) {
         self.0 = MixintGpMixtureValidParams {
             surrogate_builder: self.0.surrogate_builder.clone().n_clusters(n_clusters),
             xtypes: self.0.xtypes.clone(),

--- a/crates/ego/src/gpmix/mod.rs
+++ b/crates/ego/src/gpmix/mod.rs
@@ -5,7 +5,7 @@ pub mod spec;
 
 use egobox_gp::ThetaTuning;
 use egobox_moe::{
-    Clustering, CorrelationSpec, GpMixtureParams, MixtureGpSurrogate, RegressionSpec,
+    Clustering, CorrelationSpec, GpMixtureParams, MixtureGpSurrogate, NbClusters, RegressionSpec,
 };
 use ndarray::{ArrayView1, ArrayView2};
 
@@ -40,7 +40,7 @@ impl SurrogateBuilder for GpMixtureParams<f64> {
     }
 
     /// Sets the number of clusters used by the mixture of surrogate experts.
-    fn set_n_clusters(&mut self, n_clusters: usize) {
+    fn set_n_clusters(&mut self, n_clusters: NbClusters) {
         *self = self.clone().n_clusters(n_clusters);
     }
 

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -2,6 +2,7 @@
 use crate::criteria::*;
 use crate::types::*;
 use crate::HotStartMode;
+use egobox_moe::NbClusters;
 use egobox_moe::{CorrelationSpec, RegressionSpec};
 use ndarray::Array1;
 use ndarray::Array2;
@@ -72,9 +73,9 @@ pub struct EgorConfig {
     /// Optional dimension reduction (see [egobox_moe])
     pub(crate) kpls_dim: Option<usize>,
     /// Number of clusters used by mixture of experts (see [egobox_moe])
-    /// When set to 0 the clusters are computes automatically and refreshed
+    /// When set to Auto the clusters are computes automatically and refreshed
     /// every 10-points (tentative) additions
-    pub(crate) n_clusters: usize,
+    pub(crate) n_clusters: NbClusters,
     /// Specification of a target objective value which is used to stop the algorithm once reached
     pub(crate) target: f64,
     /// Directory to save intermediate results: inital doe + evalutions at each iteration
@@ -108,7 +109,7 @@ impl Default for EgorConfig {
             regression_spec: RegressionSpec::CONSTANT,
             correlation_spec: CorrelationSpec::SQUAREDEXPONENTIAL,
             kpls_dim: None,
-            n_clusters: 1,
+            n_clusters: NbClusters::default(),
             target: f64::NEG_INFINITY,
             outdir: None,
             warm_start: false,
@@ -239,9 +240,8 @@ impl EgorConfig {
 
     /// Sets the number of clusters used by the mixture of surrogate experts.
     ///
-    /// When set to Some(0), the number of clusters is determined automatically
-    /// When set None, default to 1
-    pub fn n_clusters(mut self, n_clusters: usize) -> Self {
+    /// When set to Auto, the number of clusters is determined automatically
+    pub fn n_clusters(mut self, n_clusters: NbClusters) -> Self {
         self.n_clusters = n_clusters;
         self
     }

--- a/crates/ego/src/solver/egor_impl.rs
+++ b/crates/ego/src/solver/egor_impl.rs
@@ -101,7 +101,8 @@ where
     C: CstrFn,
 {
     pub fn have_to_recluster(&self, added: usize, prev_added: usize) -> bool {
-        self.config.n_clusters == 0 && (added != 0 && added % 10 == 0 && added - prev_added > 0)
+        self.config.n_clusters.is_auto()
+            && (added != 0 && added % 10 == 0 && added - prev_added > 0)
     }
 
     /// Build surrogate given training data and surrogate builder
@@ -124,7 +125,7 @@ where
         builder.set_kpls_dim(self.config.kpls_dim);
         builder.set_regression_spec(self.config.regression_spec);
         builder.set_correlation_spec(self.config.correlation_spec);
-        builder.set_n_clusters(self.config.n_clusters);
+        builder.set_n_clusters(self.config.n_clusters.clone());
 
         if make_clustering
         /* init || recluster */

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -1,7 +1,7 @@
 use crate::gpmix::spec::*;
 use crate::{errors::Result, EgorState};
 use argmin::core::CostFunction;
-use egobox_moe::{Clustering, MixtureGpSurrogate, ThetaTuning};
+use egobox_moe::{Clustering, MixtureGpSurrogate, NbClusters, ThetaTuning};
 use linfa::Float;
 use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
 use serde::{Deserialize, Serialize};
@@ -140,7 +140,7 @@ pub trait SurrogateBuilder: Clone + Serialize + Sync {
     fn set_kpls_dim(&mut self, kpls_dim: Option<usize>);
 
     /// Sets the number of clusters used by the mixture of surrogate experts.
-    fn set_n_clusters(&mut self, n_clusters: usize);
+    fn set_n_clusters(&mut self, n_clusters: NbClusters);
 
     /// Sets the hyperparameters tuning strategy
     fn set_theta_tunings(&mut self, theta_tunings: &[ThetaTuning<f64>]);

--- a/crates/moe/examples/clustering.rs
+++ b/crates/moe/examples/clustering.rs
@@ -1,5 +1,5 @@
 use egobox_doe::{Lhs, SamplingMethod};
-use egobox_moe::{GpMixture, Recombination};
+use egobox_moe::{GpMixture, NbClusters, Recombination};
 use linfa::prelude::{Dataset, Fit};
 use ndarray::{arr2, Array, Array2, Axis, Zip};
 use std::error::Error;
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let ds = Dataset::new(xtrain, ytrain.remove_axis(Axis(1)));
     let moe1 = GpMixture::params().fit(&ds)?;
     let moe3 = GpMixture::params()
-        .n_clusters(3)
+        .n_clusters(NbClusters::fixed(3))
         .recombination(Recombination::Hard)
         .fit(&ds)?;
 

--- a/crates/moe/examples/moe_norm1.rs
+++ b/crates/moe/examples/moe_norm1.rs
@@ -1,6 +1,6 @@
 use csv::ReaderBuilder;
 use egobox_doe::{FullFactorial, SamplingMethod};
-use egobox_moe::GpMixture;
+use egobox_moe::{GpMixture, NbClusters};
 use linfa::{traits::Fit, Dataset};
 use ndarray::{arr2, s, Array2, Axis};
 use ndarray_csv::Array2Reader;
@@ -24,7 +24,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let xtrain = data_train.slice(s![.., ..2_usize]).to_owned();
     let ytrain = data_train.slice(s![.., 2_usize..]).to_owned();
     let ds = Dataset::new(xtrain, ytrain.remove_axis(Axis(1)));
-    let moe = GpMixture::params().n_clusters(4).fit(&ds)?;
+    let moe = GpMixture::params()
+        .n_clusters(NbClusters::fixed(4))
+        .fit(&ds)?;
 
     let xlimits = arr2(&[[-1., 1.], [-1., 1.]]);
     let xtest = FullFactorial::new(&xlimits).sample(100);

--- a/crates/moe/examples/norm1.rs
+++ b/crates/moe/examples/norm1.rs
@@ -1,5 +1,5 @@
 use egobox_doe::{Lhs, SamplingMethod};
-use egobox_moe::{GpMixture, Recombination};
+use egobox_moe::{GpMixture, NbClusters, Recombination};
 use linfa::{traits::Fit, Dataset};
 use ndarray::{arr2, Array2, Axis};
 use std::error::Error;
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let ds = Dataset::new(xtrain, ytrain.remove_axis(Axis(1)));
     let moe1 = GpMixture::params().fit(&ds)?;
     let moe5 = GpMixture::params()
-        .n_clusters(6)
+        .n_clusters(NbClusters::fixed(6))
         .recombination(Recombination::Hard)
         .fit(&ds)?;
 

--- a/crates/moe/src/algorithm.rs
+++ b/crates/moe/src/algorithm.rs
@@ -335,7 +335,7 @@ impl GpMixtureValidParams<f64> {
         if let Some(v) = best.1 {
             info!("Best expert {} accuracy={}", best.0, v);
         }
-        expert.map_err(MoeError::from)
+        expert
     }
 
     /// Take the best heaviside factor from 0.1 to 2.1 (step 0.1).

--- a/crates/moe/src/clustering.rs
+++ b/crates/moe/src/clustering.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use crate::parameters::GpMixtureParams;
-use crate::types::*;
+use crate::{types::*, NbClusters};
 use log::debug; // , info};
 
 use linfa::dataset::{Dataset, DatasetView};
@@ -66,7 +66,7 @@ pub fn find_best_number_of_clusters<R: Rng + Clone>(
     rng: R,
 ) -> (usize, Recombination<f64>) {
     let max_nb_clusters = if max_nb_clusters == 0 {
-        (x.len() / 10) + 1
+        (x.nrows() / 10) + 1
     } else {
         max_nb_clusters
     };
@@ -141,7 +141,7 @@ pub fn find_best_number_of_clusters<R: Rng + Clone>(
                 for (train, valid) in dataset.fold(5).into_iter() {
                     debug!("X: {}", Array1::from_iter(valid.records().iter().cloned()));
                     if let Ok(mixture) = GpMixtureParams::default()
-                        .n_clusters(n_clusters)
+                        .n_clusters(NbClusters::fixed(n_clusters))
                         .regression_spec(regression_spec)
                         .correlation_spec(correlation_spec)
                         .kpls_dim(kpls_dim)
@@ -468,7 +468,7 @@ mod tests {
         let xvalid = valid.sample(100);
         let yvalid = l1norm(&xvalid);
         let moe = GpMixture::params()
-            .n_clusters(n_clusters)
+            .n_clusters(NbClusters::fixed(n_clusters))
             .recombination(recomb)
             .regression_spec(RegressionSpec::LINEAR)
             .correlation_spec(CorrelationSpec::ALL)

--- a/crates/moe/src/lib.rs
+++ b/crates/moe/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! ```no_run
 //! use ndarray::{Array2, Array1, Zip, Axis};
-//! use egobox_moe::{GpMixture, Recombination};
+//! use egobox_moe::{GpMixture, Recombination, NbClusters};
 //! use ndarray_rand::{RandomExt, rand::SeedableRng, rand_distr::Uniform};
 //! use rand_xoshiro::Xoshiro256Plus;
 //! use linfa::{traits::Fit, ParamGuard, Dataset};
@@ -71,7 +71,7 @@
 //! // Predictions
 //! let observations = Array1::linspace(0., 1., 100).insert_axis(Axis(1));
 //! let predictions = GpMixture::params()
-//!                     .n_clusters(3)
+//!                     .n_clusters(NbClusters::fixed(3))
 //!                     .recombination(Recombination::Hard)
 //!                     .fit(&ds)
 //!                     .expect("MoE model training")

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -92,11 +92,13 @@ class Egor:
         trego (bool)
             When true, TREGO algorithm is used, otherwise classic EGO algorithm is used.
     
-        n_clusters (int >= 0)
-            Number of clusters used by the mixture of surrogate experts.
+        n_clusters (int)
+            Number of clusters used by the mixture of surrogate experts (default is 1).
             When set to 0, the number of cluster is determined automatically and refreshed every
             10-points addition (should say 'tentative addition' because addition may fail for some points
             but it is counted anyway).
+            When set to negative number -n, the number of clusters is determined automatically in [0, n]
+            this is used to limit the number of trials hence the execution time.
       
         n_optmod (int >= 1)
             Number of iterations between two surrogate models training (hypermarameters optimization)
@@ -439,11 +441,13 @@ class SparseGpMix:
     r"""
     Sparse Gaussian processes mixture builder
     
-        n_clusters (int >= 0)
-            Number of clusters used by the mixture of surrogate experts.
+        n_clusters (int)
+            Number of clusters used by the mixture of surrogate experts (default is 1).
             When set to 0, the number of cluster is determined automatically and refreshed every
             10-points addition (should say 'tentative addition' because addition may fail for some points
-            but failures are counted anyway).
+            but it is counted anyway).
+            When set to negative number -n, the number of clusters is determined automatically in [0, n]
+            this is used to limit the number of trials hence the execution time.
     
         corr_spec (CorrelationSpec flags, an int in [1, 15]):
             Specification of correlation models used in mixture.

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -97,7 +97,7 @@ class Egor:
             When set to 0, the number of cluster is determined automatically and refreshed every
             10-points addition (should say 'tentative addition' because addition may fail for some points
             but it is counted anyway).
-            When set to negative number -n, the number of clusters is determined automatically in [0, n]
+            When set to negative number -n, the number of clusters is determined automatically in [1, n]
             this is used to limit the number of trials hence the execution time.
       
         n_optmod (int >= 1)
@@ -446,7 +446,7 @@ class SparseGpMix:
             When set to 0, the number of cluster is determined automatically and refreshed every
             10-points addition (should say 'tentative addition' because addition may fail for some points
             but it is counted anyway).
-            When set to negative number -n, the number of clusters is determined automatically in [0, n]
+            When set to negative number -n, the number of clusters is determined automatically in [1, n]
             this is used to limit the number of trials hence the execution time.
     
         corr_spec (CorrelationSpec flags, an int in [1, 15]):

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_conversion)]
 //! `egobox`, Rust toolbox for efficient global optimization
 //!
 //! Thanks to the [PyO3 project](https://pyo3.rs), which makes Rust well suited for building Python extensions,

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -129,7 +129,7 @@ pub(crate) fn to_specs(py: Python, xlimits: Vec<Vec<f64>>) -> PyResult<PyObject>
 ///         When set to 0, the number of cluster is determined automatically and refreshed every
 ///         10-points addition (should say 'tentative addition' because addition may fail for some points
 ///         but it is counted anyway).
-///         When set to negative number -n, the number of clusters is determined automatically in [0, n]
+///         When set to negative number -n, the number of clusters is determined automatically in [1, n]
 ///         this is used to limit the number of trials hence the execution time.
 ///   
 ///     n_optmod (int >= 1)

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -10,8 +10,11 @@
 //! See the [tutorial notebook](https://github.com/relf/egobox/doc/Egor_Tutorial.ipynb) for usage.
 //!
 
+use std::cmp::Ordering;
+
 use crate::types::*;
 use egobox_ego::{find_best_result_index, InfillObjData};
+use egobox_moe::NbClusters;
 use ndarray::{concatenate, Array1, Array2, ArrayView2, Axis};
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyValueError;
@@ -120,11 +123,13 @@ pub(crate) fn to_specs(py: Python, xlimits: Vec<Vec<f64>>) -> PyResult<PyObject>
 ///     trego (bool)
 ///         When true, TREGO algorithm is used, otherwise classic EGO algorithm is used.
 ///
-///     n_clusters (int >= 0)
-///         Number of clusters used by the mixture of surrogate experts.
+///     n_clusters (int)
+///         Number of clusters used by the mixture of surrogate experts (default is 1).
 ///         When set to 0, the number of cluster is determined automatically and refreshed every
 ///         10-points addition (should say 'tentative addition' because addition may fail for some points
 ///         but it is counted anyway).
+///         When set to negative number -n, the number of clusters is determined automatically in [0, n]
+///         this is used to limit the number of trials hence the execution time.
 ///   
 ///     n_optmod (int >= 1)
 ///         Number of iterations between two surrogate models training (hypermarameters optimization)
@@ -169,7 +174,7 @@ pub(crate) struct Egor {
     pub infill_optimizer: InfillOptimizer,
     pub kpls_dim: Option<usize>,
     pub trego: bool,
-    pub n_clusters: Option<usize>,
+    pub n_clusters: NbClusters,
     pub n_optmod: usize,
     pub target: f64,
     pub outdir: Option<String>,
@@ -233,7 +238,7 @@ impl Egor {
         infill_optimizer: InfillOptimizer,
         kpls_dim: Option<usize>,
         trego: bool,
-        n_clusters: Option<usize>,
+        n_clusters: isize,
         n_optmod: usize,
         target: f64,
         outdir: Option<String>,
@@ -242,6 +247,13 @@ impl Egor {
         seed: Option<u64>,
     ) -> Self {
         let doe = doe.map(|x| x.to_owned_array());
+
+        let n_clusters = match n_clusters.cmp(&0) {
+            Ordering::Greater => NbClusters::fixed(n_clusters as usize),
+            Ordering::Equal => NbClusters::auto(),
+            Ordering::Less => NbClusters::automax(-n_clusters as usize),
+        };
+
         Egor {
             xspecs,
             n_cstr,
@@ -512,6 +524,7 @@ impl Egor {
         let cstr_tol = self.cstr_tol(n_fcstr);
 
         let mut config = config
+            .n_clusters(self.n_clusters.clone())
             .n_cstr(self.n_cstr)
             .max_iters(max_iters.unwrap_or(1))
             .n_start(self.n_start)
@@ -535,9 +548,6 @@ impl Egor {
         };
         if let Some(kpls_dim) = self.kpls_dim {
             config = config.kpls_dim(kpls_dim);
-        };
-        if let Some(n_clusters) = self.n_clusters {
-            config = config.n_clusters(n_clusters);
         };
         if let Some(outdir) = self.outdir.as_ref().cloned() {
             config = config.outdir(outdir);

--- a/python/src/gp_mix.rs
+++ b/python/src/gp_mix.rs
@@ -31,7 +31,7 @@ use rand_xoshiro::Xoshiro256Plus;
 ///         When set to 0, the number of cluster is determined automatically and refreshed every
 ///         10-points addition (should say 'tentative addition' because addition may fail for some points
 ///         but it is counted anyway).
-///         When set to negative number -n, the number of clusters is determined automatically in [0, n]
+///         When set to negative number -n, the number of clusters is determined automatically in [1, n]
 ///         this is used to limit the number of trials hence the execution time.
 ///
 ///     regr_spec (RegressionSpec flags, an int in [1, 7]):


### PR DESCRIPTION
Number of points in clusters is now checked wrt regression spec. See `check_number_of_points()`
 
This PR refactors the type to specify clustering specification: either defined by the user or automatically computed. See `NbClusters` type. Now when determined automatically a max number of clusters can be specified to shorten execution time.
Python binding: The `n_clusters` argument can take negative values `-n` to specify that the number of clusters tested is in [1, n].

This PR relates to #243 
