### PR TITLE
Refactor infill criterion optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ mopta08_elf64.bin
 **/.checkpoints
 **/checkpoint*
 *.arg
+slurm*.out
+slurm*.err
 
 # JOSS
 joss/paper.jats

--- a/crates/doe/src/lhs.rs
+++ b/crates/doe/src/lhs.rs
@@ -39,7 +39,7 @@ type RngRef<R> = Arc<RwLock<R>>;
 /// The selection method gives different kind of LHS (see [LhsKind])
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
-pub struct Lhs<F: Float, R: Rng + Clone> {
+pub struct Lhs<F: Float, R: Rng> {
     /// Sampling space definition as a (nx, 2) matrix
     /// The ith row is the [lower_bound, upper_bound] of xi, the ith component of x
     xlimits: Array2<F>,
@@ -64,7 +64,7 @@ impl<F: Float> Lhs<F, Xoshiro256Plus> {
     }
 }
 
-impl<F: Float, R: Rng + Clone> SamplingMethod<F> for Lhs<F, R> {
+impl<F: Float, R: Rng> SamplingMethod<F> for Lhs<F, R> {
     fn sampling_space(&self) -> &Array2<F> {
         &self.xlimits
     }
@@ -86,7 +86,7 @@ impl<F: Float, R: Rng + Clone> SamplingMethod<F> for Lhs<F, R> {
     }
 }
 
-impl<F: Float, R: Rng + Clone> Lhs<F, R> {
+impl<F: Float, R: Rng> Lhs<F, R> {
     /// Constructor with given design space and random generator.
     /// * `xlimits`: (nx, 2) matrix where nx is the dimension of the samples and the ith row
     ///   is the definition interval of the ith component of x.
@@ -109,7 +109,7 @@ impl<F: Float, R: Rng + Clone> Lhs<F, R> {
     }
 
     /// Sets the random generator
-    pub fn with_rng<R2: Rng + Clone>(self, rng: R2) -> Lhs<F, R2> {
+    pub fn with_rng<R2: Rng>(self, rng: R2) -> Lhs<F, R2> {
         Lhs {
             xlimits: self.xlimits,
             kind: self.kind,

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -720,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn test_egor_g24_basic_egor_builder() {
+    fn test_egor_g24_basic_egor_builder_slsqp() {
         let xlimits = array![[0., 3.], [0., 4.]];
         let doe = Lhs::new(&xlimits)
             .with_rng(Xoshiro256Plus::seed_from_u64(42))
@@ -730,7 +730,7 @@ mod tests {
                 config
                     .n_cstr(2)
                     .doe(&doe)
-                    .max_iters(20)
+                    .max_iters(30)
                     .cstr_tol(array![2e-6, 1e-6])
                     .seed(42)
             })

--- a/crates/ego/src/optimizers/lhs_optimizer.rs
+++ b/crates/ego/src/optimizers/lhs_optimizer.rs
@@ -16,7 +16,7 @@ use ndarray_stats::QuantileExt;
 #[cfg(feature = "nlopt")]
 use nlopt::ObjFn;
 
-pub(crate) struct LhsOptimizer<'a, R: Rng + Clone + Sync + Send> {
+pub(crate) struct LhsOptimizer<'a, R: Rng + Sync + Send> {
     xlimits: Array2<f64>,
     n_start: usize,
     n_points: usize,
@@ -64,7 +64,7 @@ impl<'a, R: Rng + Clone + Sync + Send> LhsOptimizer<'a, R> {
         }
     }
 
-    pub fn with_rng<R2: Rng + Clone + Sync + Send>(self, rng: R2) -> LhsOptimizer<'a, R2> {
+    pub fn with_rng<R2: Rng + Sync + Send>(self, rng: R2) -> LhsOptimizer<'a, R2> {
         LhsOptimizer {
             xlimits: self.xlimits,
             n_start: self.n_start,

--- a/crates/ego/src/solver/coego.rs
+++ b/crates/ego/src/solver/coego.rs
@@ -6,6 +6,7 @@ use crate::EgorSolver;
 use egobox_gp::ThetaTuning;
 use egobox_moe::MixtureGpSurrogate;
 use ndarray::{s, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, RemoveAxis};
+use rand_xoshiro::Xoshiro256Plus;
 use serde::de::DeserializeOwned;
 
 use ndarray_rand::rand::seq::SliceRandom;
@@ -51,7 +52,7 @@ where
     /// active component during partial optimizations
     /// Array is (group nb, group size) where nb and size are computed
     /// from nx dimension and n_coop configuration.  
-    pub(crate) fn get_random_activity(&mut self) -> Array2<usize> {
+    pub(crate) fn get_random_activity(&mut self, rng: &mut Xoshiro256Plus) -> Array2<usize> {
         let xdim = self.xlimits.nrows();
         let g_size = xdim / self.config.coego.n_coop.max(1);
         let g_nb = if xdim % self.config.coego.n_coop == 0 {
@@ -64,7 +65,7 @@ where
         // When n_coop is not a diviser of xdim, indice is set to xdim
         // (ie out of range) as to be filtered when handling last activity row
         let mut idx: Vec<usize> = (0..xdim).collect();
-        idx.shuffle(&mut self.rng);
+        idx.shuffle(rng);
         let mut indices = vec![xdim; g_size * g_nb];
         indices[..xdim].copy_from_slice(&idx);
 

--- a/crates/ego/src/solver/egor_service.rs
+++ b/crates/ego/src/solver/egor_service.rs
@@ -46,8 +46,7 @@ use crate::{to_xtypes, types::*, EgorConfig, EgorSolver};
 
 use egobox_moe::GpMixtureParams;
 use ndarray::{Array2, ArrayBase, Data, Ix2};
-use ndarray_rand::rand::SeedableRng;
-use rand_xoshiro::Xoshiro256Plus;
+
 use serde::de::DeserializeOwned;
 
 /// EGO optimizer service builder allowing to use Egor optimizer
@@ -84,17 +83,12 @@ impl<C: CstrFn> EgorServiceFactory<C> {
         self,
         xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> EgorServiceApi<GpMixtureParams<f64>, C> {
-        let rng = if let Some(seed) = self.config.seed {
-            Xoshiro256Plus::seed_from_u64(seed)
-        } else {
-            Xoshiro256Plus::from_entropy()
-        };
         let config = EgorConfig {
             xtypes: to_xtypes(xlimits),
             ..self.config.clone()
         };
         EgorServiceApi {
-            solver: EgorSolver::new(config, rng),
+            solver: EgorSolver::new(config),
         }
     }
 
@@ -105,17 +99,12 @@ impl<C: CstrFn> EgorServiceFactory<C> {
         self,
         xtypes: &[XType],
     ) -> EgorServiceApi<MixintGpMixtureParams, C> {
-        let rng = if let Some(seed) = self.config.seed {
-            Xoshiro256Plus::seed_from_u64(seed)
-        } else {
-            Xoshiro256Plus::from_entropy()
-        };
         let config = EgorConfig {
             xtypes: xtypes.to_vec(),
             ..self.config.clone()
         };
         EgorServiceApi {
-            solver: EgorSolver::new(config, rng),
+            solver: EgorSolver::new(config),
         }
     }
 }

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -353,7 +353,7 @@ where
         }
     }
 
-    /// Itertation of TREGO algorithm
+    /// Iteration of TREGO algorithm
     fn trego_iteration<
         O: CostFunction<Param = Array2<f64>, Output = Array2<f64>> + DomainConstraints<C>,
     >(

--- a/crates/ego/src/solver/mod.rs
+++ b/crates/ego/src/solver/mod.rs
@@ -5,6 +5,7 @@ mod egor_solver;
 mod egor_state;
 mod solver_computations;
 mod solver_impl;
+mod solver_infill_optim;
 mod trego;
 
 pub use egor_config::*;

--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -1,31 +1,40 @@
 use crate::errors::Result;
 use crate::gpmix::mixint::to_discrete_space;
-use crate::optimizers::*;
 use crate::types::*;
 
 use crate::utils::{compute_cstr_scales, pofs, pofs_grad};
 use crate::EgorSolver;
 
-#[cfg(not(feature = "nlopt"))]
-use crate::types::ObjFn;
-#[cfg(feature = "nlopt")]
-use nlopt::ObjFn;
-
 use argmin::core::{CostFunction, Problem};
 
 use egobox_doe::{Lhs, SamplingMethod};
-// use finitediff::FiniteDiff;
-
 use egobox_moe::MixtureGpSurrogate;
+
 use log::{debug, info, warn};
 use ndarray::{s, Array, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, Ix1, Ix2, Zip};
 
 use ndarray_stats::QuantileExt;
 use rand_xoshiro::Xoshiro256Plus;
-use rayon::prelude::*;
 use serde::de::DeserializeOwned;
 
 const CSTR_DOUBT: f64 = 3.;
+
+pub(crate) struct GlobalMultiStarter<'a> {
+    n_start: usize,
+    sampling: &'a Lhs<f64, Xoshiro256Plus>,
+}
+
+impl super::solver_infill_optim::MultiStarter for GlobalMultiStarter<'_> {
+    fn multistart(&self) -> Array2<f64> {
+        self.sampling.sample(self.n_start)
+    }
+}
+
+impl<'a> GlobalMultiStarter<'a> {
+    pub fn new(n_start: usize, sampling: &'a Lhs<f64, Xoshiro256Plus>) -> Self {
+        GlobalMultiStarter { n_start, sampling }
+    }
+}
 
 impl<SB, C> EgorSolver<SB, C>
 where
@@ -88,247 +97,6 @@ where
             scale_fcstr
         };
         (scale_infill_obj, scale_cstr, scale_fcstr, scale_ic)
-    }
-
-    /// Find best x promising points by optimizing the chosen infill criterion
-    /// The optimized value of the criterion is returned together with the
-    /// optimum location
-    /// Returns (infill_obj, x_opt)
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn compute_best_point(
-        &self,
-        obj_model: &dyn MixtureGpSurrogate,
-        cstr_models: &[Box<dyn MixtureGpSurrogate>],
-        cstr_funcs: &[impl CstrFn],
-        cstr_tols: &Array1<f64>,
-        lhs_optim_seed: Option<u64>,
-        infill_data: &InfillObjData<f64>,
-        current_best: (f64, Array1<f64>, Array1<f64>, Array1<f64>),
-        actives: &Array2<usize>,
-        sampling: &Lhs<f64, Xoshiro256Plus>,
-    ) -> (f64, Array1<f64>) {
-        let mut infill_data = infill_data.clone();
-
-        let mut best_point = (current_best.0, current_best.1.to_owned());
-        let mut current_best_point = current_best.to_owned();
-
-        for (i, active) in actives.outer_iter().enumerate() {
-            let mut success = false;
-            let mut n_optim = 1;
-            let n_max_optim = 3;
-
-            let active = active.to_vec();
-            let obj = |x: &[f64],
-                       gradient: Option<&mut [f64]>,
-                       params: &mut InfillObjData<f64>|
-             -> f64 {
-                let InfillObjData {
-                    scale_infill_obj,
-                    scale_wb2,
-                    xbest: xcoop,
-                    fmin,
-                    ..
-                } = params;
-                let mut xcoop = xcoop.clone();
-                Self::setx(&mut xcoop, &active, x);
-
-                // Defensive programming NlOpt::Cobyla may pass NaNs
-                if xcoop.iter().any(|x| x.is_nan()) {
-                    return f64::INFINITY;
-                }
-
-                if let Some(grad) = gradient {
-                    // Use finite differences
-                    // let f = |x: &Vec<f64>| -> f64 {
-                    //     self.eval_infill_obj(x, obj_model, fmin, *scale_infill_obj, *scale_wb2)
-                    // };
-                    // grad[..].copy_from_slice(&x.to_vec().central_diff(&f));
-
-                    let g_infill_obj = if self.config.cstr_infill {
-                        self.eval_grad_infill_obj_with_cstrs(
-                            &xcoop,
-                            obj_model,
-                            cstr_models,
-                            cstr_tols,
-                            *fmin,
-                            *scale_infill_obj,
-                            *scale_wb2,
-                        )
-                    } else {
-                        self.eval_grad_infill_obj(
-                            &xcoop,
-                            obj_model,
-                            *fmin,
-                            *scale_infill_obj,
-                            *scale_wb2,
-                        )
-                    };
-                    let g_infill_obj = g_infill_obj
-                        .iter()
-                        .enumerate()
-                        .filter(|(i, _)| active.contains(i))
-                        .map(|(_, &g)| g)
-                        .collect::<Vec<_>>();
-                    grad[..].copy_from_slice(&g_infill_obj);
-                }
-                if self.config.cstr_infill {
-                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
-                        * pofs(&xcoop, cstr_models, &cstr_tols.to_vec())
-                } else {
-                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
-                }
-            };
-
-            let cstrs: Vec<_> = if self.config.cstr_infill {
-                vec![]
-            } else {
-                (0..self.config.n_cstr)
-                    .map(|i| {
-                        let active = active.to_vec();
-                        let cstr = move |x: &[f64],
-                                         gradient: Option<&mut [f64]>,
-                                         params: &mut InfillObjData<f64>|
-                              -> f64 {
-                            let InfillObjData { xbest: xcoop, .. } = params;
-                            let mut xcoop = xcoop.clone();
-                            Self::setx(&mut xcoop, &active, x);
-
-                            let scale_cstr =
-                                params.scale_cstr.as_ref().expect("constraint scaling")[i];
-                            if self.config.cstr_strategy == ConstraintStrategy::MeanConstraint {
-                                Self::mean_cstr(
-                                    &*cstr_models[i],
-                                    &xcoop,
-                                    gradient,
-                                    scale_cstr,
-                                    &active,
-                                )
-                            } else {
-                                Self::upper_trust_bound_cstr(
-                                    &*cstr_models[i],
-                                    &xcoop,
-                                    gradient,
-                                    scale_cstr,
-                                    &active,
-                                )
-                            }
-                        };
-                        #[cfg(feature = "nlopt")]
-                        {
-                            Box::new(cstr) as Box<dyn nlopt::ObjFn<InfillObjData<f64>> + Sync>
-                        }
-                        #[cfg(not(feature = "nlopt"))]
-                        {
-                            Box::new(cstr)
-                                as Box<dyn crate::types::ObjFn<InfillObjData<f64>> + Sync>
-                        }
-                    })
-                    .collect()
-            };
-
-            // We merge metamodelized constraints and function constraints
-            let mut cstr_refs: Vec<_> = cstrs.iter().map(|c| c.as_ref()).collect();
-            let cstr_funcs = cstr_funcs
-                .iter()
-                .map(|cstr| cstr as &(dyn ObjFn<InfillObjData<f64>> + Sync))
-                .collect::<Vec<_>>();
-            cstr_refs.extend(cstr_funcs.clone());
-
-            // Limits
-            let xlimits = Self::getx(&self.xlimits, Axis(0), &active);
-
-            let algorithm = match self.config.infill_optimizer {
-                InfillOptimizer::Slsqp => crate::optimizers::Algorithm::Slsqp,
-                InfillOptimizer::Cobyla => crate::optimizers::Algorithm::Cobyla,
-            };
-
-            if i == 0 {
-                info!("Optimize infill criterion...");
-            }
-            while !success && n_optim <= n_max_optim {
-                let x_start = sampling.sample(self.config.n_start);
-                let x_start_coop = Self::getx(&x_start, Axis(1), &active);
-
-                if let Some(seed) = lhs_optim_seed {
-                    let (y_opt, x_opt) =
-                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
-                            .cstr_tol(cstr_tols.to_owned())
-                            .seed(seed)
-                            .minimize();
-
-                    info!("LHS optimization best_x {}", x_opt);
-                    best_point = (y_opt, x_opt);
-                    success = true;
-                } else {
-                    let res = (0..self.config.n_start)
-                        .into_par_iter()
-                        .map(|i| {
-                            debug!("Begin optim {}", i);
-                            let optim_res =
-                                Optimizer::new(algorithm, &obj, &cstr_refs, &infill_data, &xlimits)
-                                    .xinit(&x_start_coop.row(i))
-                                    .max_eval((10 * x_start_coop.len()).min(MAX_EVAL_DEFAULT))
-                                    .ftol_rel(1e-4)
-                                    .ftol_abs(1e-4)
-                                    .minimize();
-                            debug!("End optim {}", i);
-                            optim_res
-                        })
-                        .reduce(
-                            || (f64::INFINITY, Array::ones((xlimits.nrows(),))),
-                            |a, b| if b.0 < a.0 { b } else { a },
-                        );
-
-                    if res.0.is_nan() || res.0.is_infinite() {
-                        success = false;
-                    } else {
-                        let mut xopt_coop = current_best_point.1.to_vec();
-                        Self::setx(&mut xopt_coop, &active, &res.1.to_vec());
-                        infill_data.xbest = xopt_coop.clone();
-                        let xopt_coop = Array1::from(xopt_coop);
-
-                        if crate::solver::coego::COEGO_IMPROVEMENT_CHECK {
-                            let (is_better, best) = self.is_objective_improved(
-                                &current_best_point,
-                                &xopt_coop,
-                                obj_model,
-                                cstr_models,
-                                cstr_tols,
-                                &cstr_funcs,
-                            );
-                            if is_better || i == 0 {
-                                if i > 0 {
-                                    info!(
-                                        "Partial infill criterion optim c={} has better result={} at x={}",
-                                        i, best.0, xopt_coop
-                                    );
-                                }
-                                best_point = (res.0, xopt_coop);
-                                current_best_point = best;
-                            }
-                        } else {
-                            best_point = (res.0, xopt_coop.to_owned());
-                            current_best_point =
-                                (res.0, xopt_coop, current_best_point.2, current_best_point.3);
-                        }
-                        success = true;
-                    }
-                }
-
-                if n_optim == n_max_optim && !success {
-                    log::warn!("All optimizations fail => Trigger LHS optimization");
-                    let (y_opt, x_opt) =
-                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
-                            .minimize();
-
-                    info!("LHS optimization best_x {}", x_opt);
-                    best_point = (y_opt, x_opt);
-                    success = true;
-                }
-                n_optim += 1;
-            }
-        }
-        best_point
     }
 
     pub fn mean_cstr(

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -628,7 +628,6 @@ where
                 .collect::<Vec<_>>();
 
             let (infill_obj, xk) = self.compute_best_point(
-                sampling,
                 obj_model.as_ref(),
                 cstr_models,
                 &cstr_funcs,
@@ -637,6 +636,7 @@ where
                 &infill_data,
                 (fmin, xbest, ybest, cbest),
                 &actives,
+                sampling,
             );
 
             match self.compute_virtual_point(&xk, y_data, obj_model.as_ref(), cstr_models) {

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -7,6 +7,7 @@ use crate::{find_best_result_index, EgorConfig};
 use crate::{types::*, EgorState};
 use crate::{EgorSolver, DEFAULT_CSTR_TOL, MAX_POINT_ADDITION_RETRY};
 
+use super::solver_computations::GlobalMultiStarter;
 use argmin::argmin_error_closure;
 use argmin::core::{CostFunction, Problem, State};
 
@@ -627,7 +628,9 @@ where
                 })
                 .collect::<Vec<_>>();
 
-            let (infill_obj, xk) = self.compute_best_point(
+            let multistarter = GlobalMultiStarter::new(self.config.n_start, sampling);
+
+            let (infill_obj, xk) = self.optimize_infill_criterion(
                 obj_model.as_ref(),
                 cstr_models,
                 &cstr_funcs,
@@ -636,7 +639,7 @@ where
                 &infill_data,
                 (fmin, xbest, ybest, cbest),
                 &actives,
-                sampling,
+                multistarter,
             );
 
             match self.compute_virtual_point(&xk, y_data, obj_model.as_ref(), cstr_models) {

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -19,6 +19,7 @@ use egobox_moe::{Clustering, MixtureGpSurrogate, NbClusters};
 use log::{debug, info, warn};
 use ndarray::{concatenate, s, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2, Zip};
 
+use ndarray_rand::rand::SeedableRng;
 use rand_xoshiro::Xoshiro256Plus;
 use rayon::prelude::*;
 use serde::de::DeserializeOwned;
@@ -31,7 +32,7 @@ impl<SB: SurrogateBuilder + DeserializeOwned, C: CstrFn> EgorSolver<SB, C> {
     ///
     /// The function `f` should return an objective but also constraint values if any.
     /// Design space is specified by a list of types for input variables `x` of `f` (see [`XType`]).
-    pub fn new(config: EgorConfig, rng: Xoshiro256Plus) -> Self {
+    pub fn new(config: EgorConfig) -> Self {
         let env = Env::new().filter_or("EGOBOX_LOG", "info");
         let mut builder = Builder::from_env(env);
         let builder = builder.target(env_logger::Target::Stdout);
@@ -41,7 +42,6 @@ impl<SB: SurrogateBuilder + DeserializeOwned, C: CstrFn> EgorSolver<SB, C> {
             config,
             xlimits: as_continuous_limits(&xtypes),
             surrogate_builder: SB::new_with_xtypes(&xtypes),
-            rng,
             phantom: PhantomData,
         }
     }
@@ -55,7 +55,11 @@ impl<SB: SurrogateBuilder + DeserializeOwned, C: CstrFn> EgorSolver<SB, C> {
         x_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
         y_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Array2<f64> {
-        let rng = self.rng.clone();
+        let rng = if let Some(seed) = self.config.seed {
+            Xoshiro256Plus::seed_from_u64(seed)
+        } else {
+            Xoshiro256Plus::from_entropy()
+        };
         let sampling = Lhs::new(&self.xlimits).with_rng(rng).kind(LhsKind::Maximin);
         let mut clusterings = vec![None; 1 + self.config.n_cstr];
         let mut theta_tunings = vec![None; 1 + self.config.n_cstr];

--- a/crates/ego/src/solver/solver_infill_optim.rs
+++ b/crates/ego/src/solver/solver_infill_optim.rs
@@ -1,0 +1,271 @@
+use crate::optimizers::*;
+use crate::types::*;
+
+use crate::utils::pofs;
+use crate::EgorSolver;
+
+#[cfg(not(feature = "nlopt"))]
+use crate::types::ObjFn;
+#[cfg(feature = "nlopt")]
+use nlopt::ObjFn;
+
+use egobox_moe::MixtureGpSurrogate;
+use log::{debug, info};
+use ndarray::{Array, Array1, Array2, Axis};
+
+use rayon::prelude::*;
+use serde::de::DeserializeOwned;
+
+pub(crate) trait MultiStarter {
+    fn multistart(&self) -> Array2<f64>;
+}
+
+impl<SB, C> EgorSolver<SB, C>
+where
+    SB: SurrogateBuilder + DeserializeOwned,
+    C: CstrFn,
+{
+    /// Find best x promising points by optimizing the chosen infill criterion
+    /// The optimized value of the criterion is returned together with the
+    /// optimum location
+    /// Returns (infill_obj, x_opt)
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn optimize_infill_criterion<MS>(
+        &self,
+        obj_model: &dyn MixtureGpSurrogate,
+        cstr_models: &[Box<dyn MixtureGpSurrogate>],
+        cstr_funcs: &[impl CstrFn],
+        cstr_tols: &Array1<f64>,
+        lhs_optim_seed: Option<u64>,
+        infill_data: &InfillObjData<f64>,
+        current_best: (f64, Array1<f64>, Array1<f64>, Array1<f64>),
+        actives: &Array2<usize>,
+        multistarter: MS,
+    ) -> (f64, Array1<f64>)
+    where
+        MS: MultiStarter,
+    {
+        let mut infill_data = infill_data.clone();
+
+        let mut best_point = (current_best.0, current_best.1.to_owned());
+        let mut current_best_point = current_best.to_owned();
+
+        for (i, active) in actives.outer_iter().enumerate() {
+            let mut success = false;
+            let mut n_optim = 1;
+            let n_max_optim = 3;
+
+            let active = active.to_vec();
+            let obj = |x: &[f64],
+                       gradient: Option<&mut [f64]>,
+                       params: &mut InfillObjData<f64>|
+             -> f64 {
+                let InfillObjData {
+                    scale_infill_obj,
+                    scale_wb2,
+                    xbest: xcoop,
+                    fmin,
+                    ..
+                } = params;
+                let mut xcoop = xcoop.clone();
+                Self::setx(&mut xcoop, &active, x);
+
+                // Defensive programming NlOpt::Cobyla may pass NaNs
+                if xcoop.iter().any(|x| x.is_nan()) {
+                    return f64::INFINITY;
+                }
+
+                if let Some(grad) = gradient {
+                    // Use finite differences
+                    // let f = |x: &Vec<f64>| -> f64 {
+                    //     self.eval_infill_obj(x, obj_model, fmin, *scale_infill_obj, *scale_wb2)
+                    // };
+                    // grad[..].copy_from_slice(&x.to_vec().central_diff(&f));
+
+                    let g_infill_obj = if self.config.cstr_infill {
+                        self.eval_grad_infill_obj_with_cstrs(
+                            &xcoop,
+                            obj_model,
+                            cstr_models,
+                            cstr_tols,
+                            *fmin,
+                            *scale_infill_obj,
+                            *scale_wb2,
+                        )
+                    } else {
+                        self.eval_grad_infill_obj(
+                            &xcoop,
+                            obj_model,
+                            *fmin,
+                            *scale_infill_obj,
+                            *scale_wb2,
+                        )
+                    };
+                    let g_infill_obj = g_infill_obj
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| active.contains(i))
+                        .map(|(_, &g)| g)
+                        .collect::<Vec<_>>();
+                    grad[..].copy_from_slice(&g_infill_obj);
+                }
+                if self.config.cstr_infill {
+                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
+                        * pofs(&xcoop, cstr_models, &cstr_tols.to_vec())
+                } else {
+                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
+                }
+            };
+
+            let cstrs: Vec<_> = if self.config.cstr_infill {
+                vec![]
+            } else {
+                (0..self.config.n_cstr)
+                    .map(|i| {
+                        let active = active.to_vec();
+                        let cstr = move |x: &[f64],
+                                         gradient: Option<&mut [f64]>,
+                                         params: &mut InfillObjData<f64>|
+                              -> f64 {
+                            let InfillObjData { xbest: xcoop, .. } = params;
+                            let mut xcoop = xcoop.clone();
+                            Self::setx(&mut xcoop, &active, x);
+
+                            let scale_cstr =
+                                params.scale_cstr.as_ref().expect("constraint scaling")[i];
+                            if self.config.cstr_strategy == ConstraintStrategy::MeanConstraint {
+                                Self::mean_cstr(
+                                    &*cstr_models[i],
+                                    &xcoop,
+                                    gradient,
+                                    scale_cstr,
+                                    &active,
+                                )
+                            } else {
+                                Self::upper_trust_bound_cstr(
+                                    &*cstr_models[i],
+                                    &xcoop,
+                                    gradient,
+                                    scale_cstr,
+                                    &active,
+                                )
+                            }
+                        };
+                        #[cfg(feature = "nlopt")]
+                        {
+                            Box::new(cstr) as Box<dyn nlopt::ObjFn<InfillObjData<f64>> + Sync>
+                        }
+                        #[cfg(not(feature = "nlopt"))]
+                        {
+                            Box::new(cstr)
+                                as Box<dyn crate::types::ObjFn<InfillObjData<f64>> + Sync>
+                        }
+                    })
+                    .collect()
+            };
+
+            // We merge metamodelized constraints and function constraints
+            let mut cstr_refs: Vec<_> = cstrs.iter().map(|c| c.as_ref()).collect();
+            let cstr_funcs = cstr_funcs
+                .iter()
+                .map(|cstr| cstr as &(dyn ObjFn<InfillObjData<f64>> + Sync))
+                .collect::<Vec<_>>();
+            cstr_refs.extend(cstr_funcs.clone());
+
+            // Limits
+            let xlimits = Self::getx(&self.xlimits, Axis(0), &active);
+
+            let algorithm = match self.config.infill_optimizer {
+                InfillOptimizer::Slsqp => crate::optimizers::Algorithm::Slsqp,
+                InfillOptimizer::Cobyla => crate::optimizers::Algorithm::Cobyla,
+            };
+
+            if i == 0 {
+                info!("Optimize infill criterion...");
+            }
+            while !success && n_optim <= n_max_optim {
+                let x_start = multistarter.multistart();
+                let x_start_coop = Self::getx(&x_start, Axis(1), &active);
+
+                if let Some(seed) = lhs_optim_seed {
+                    let (y_opt, x_opt) =
+                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
+                            .cstr_tol(cstr_tols.to_owned())
+                            .seed(seed)
+                            .minimize();
+
+                    info!("LHS optimization best_x {}", x_opt);
+                    best_point = (y_opt, x_opt);
+                    success = true;
+                } else {
+                    let res = (0..self.config.n_start)
+                        .into_par_iter()
+                        .map(|i| {
+                            debug!("Begin optim {}", i);
+                            let optim_res =
+                                Optimizer::new(algorithm, &obj, &cstr_refs, &infill_data, &xlimits)
+                                    .xinit(&x_start_coop.row(i))
+                                    .max_eval((10 * x_start_coop.len()).min(MAX_EVAL_DEFAULT))
+                                    .ftol_rel(1e-4)
+                                    .ftol_abs(1e-4)
+                                    .minimize();
+                            debug!("End optim {}", i);
+                            optim_res
+                        })
+                        .reduce(
+                            || (f64::INFINITY, Array::ones((xlimits.nrows(),))),
+                            |a, b| if b.0 < a.0 { b } else { a },
+                        );
+
+                    if res.0.is_nan() || res.0.is_infinite() {
+                        success = false;
+                    } else {
+                        let mut xopt_coop = current_best_point.1.to_vec();
+                        Self::setx(&mut xopt_coop, &active, &res.1.to_vec());
+                        infill_data.xbest = xopt_coop.clone();
+                        let xopt_coop = Array1::from(xopt_coop);
+
+                        if crate::solver::coego::COEGO_IMPROVEMENT_CHECK {
+                            let (is_better, best) = self.is_objective_improved(
+                                &current_best_point,
+                                &xopt_coop,
+                                obj_model,
+                                cstr_models,
+                                cstr_tols,
+                                &cstr_funcs,
+                            );
+                            if is_better || i == 0 {
+                                if i > 0 {
+                                    info!(
+                                        "Partial infill criterion optim c={} has better result={} at x={}",
+                                        i, best.0, xopt_coop
+                                    );
+                                }
+                                best_point = (res.0, xopt_coop);
+                                current_best_point = best;
+                            }
+                        } else {
+                            best_point = (res.0, xopt_coop.to_owned());
+                            current_best_point =
+                                (res.0, xopt_coop, current_best_point.2, current_best_point.3);
+                        }
+                        success = true;
+                    }
+                }
+
+                if n_optim == n_max_optim && !success {
+                    log::warn!("All optimizations fail => Trigger LHS optimization");
+                    let (y_opt, x_opt) =
+                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
+                            .minimize();
+
+                    info!("LHS optimization best_x {}", x_opt);
+                    best_point = (y_opt, x_opt);
+                    success = true;
+                }
+                n_optim += 1;
+            }
+        }
+        best_point
+    }
+}

--- a/crates/ego/src/solver/trego.rs
+++ b/crates/ego/src/solver/trego.rs
@@ -1,14 +1,10 @@
-use crate::optimizers::*;
 use crate::types::DomainConstraints;
 use crate::utils::find_best_result_index_from;
-use crate::utils::pofs;
 use crate::utils::update_data;
-use crate::ConstraintStrategy;
 use crate::CstrFn;
 use crate::EgorSolver;
 use crate::EgorState;
 use crate::InfillObjData;
-use crate::InfillOptimizer;
 use crate::SurrogateBuilder;
 
 use argmin::core::CostFunction;
@@ -18,21 +14,49 @@ use egobox_doe::Lhs;
 use egobox_doe::SamplingMethod;
 use egobox_moe::MixtureGpSurrogate;
 
-// use finitediff::FiniteDiff;
 use log::debug;
 use log::info;
 use ndarray::aview1;
 use ndarray::Zip;
-use ndarray::{Array, Array1, Array2, ArrayView1, Axis};
+use ndarray::{Array1, Array2, Axis};
 
-use rand_xoshiro::Xoshiro256Plus;
-use rayon::prelude::*;
+use ndarray_rand::rand::Rng;
 use serde::de::DeserializeOwned;
 
-#[cfg(not(feature = "nlopt"))]
-use crate::types::ObjFn;
-#[cfg(feature = "nlopt")]
-use nlopt::ObjFn;
+use super::solver_infill_optim::MultiStarter;
+
+/// LocalMultiStarter is a multistart strategy that samples points in the local area
+/// defined by the trust region and the xlimits.
+struct LocalMultiStarter<R: Rng + Clone> {
+    n_start: usize,
+    xlimits: Array2<f64>,
+    origin: Array1<f64>,
+    local_bounds: (f64, f64),
+    rng: R,
+}
+
+impl<R: Rng + Clone> MultiStarter for LocalMultiStarter<R> {
+    fn multistart(&self) -> Array2<f64> {
+        // Draw n_start initial points (multistart optim) in the local_area
+        // local_area = intersection(trust_region, xlimits)
+        let mut local_area = Array2::zeros((self.xlimits.nrows(), self.xlimits.ncols()));
+        Zip::from(local_area.rows_mut())
+            .and(&self.origin)
+            .and(self.xlimits.rows())
+            .for_each(|mut row, xb, xlims| {
+                let (lo, up) = (
+                    xlims[0].max(xb - self.local_bounds.0),
+                    xlims[1].min(xb + self.local_bounds.1),
+                );
+                row.assign(&aview1(&[lo, up]))
+            });
+
+        let lhs = Lhs::new(&local_area)
+            .kind(egobox_doe::LhsKind::Maximin)
+            .with_rng(self.rng.clone());
+        lhs.sample(self.n_start)
+    }
+}
 
 impl<SB, C> EgorSolver<SB, C>
 where
@@ -68,7 +92,16 @@ where
         // Optimize infill criterion
         let activity = new_state.activity.clone();
         let actives = activity.unwrap_or(self.full_activity()).to_owned();
-        let (infill_obj, x_opt) = self.compute_local_best_point(
+
+        let multistarter = LocalMultiStarter {
+            n_start: self.config.n_start,
+            xlimits: self.xlimits.clone(),
+            origin: xbest.to_owned(),
+            local_bounds: (self.config.trego.d.0, self.config.trego.d.1),
+            rng: self.rng.clone(),
+        };
+
+        let (infill_obj, x_opt) = self.optimize_infill_criterion(
             obj_model.as_ref(),
             cstr_models,
             fcstrs,
@@ -77,11 +110,7 @@ where
             infill_data,
             (fmin, xbest.to_owned(), ybest, cbest),
             &actives,
-            &xbest.view(),
-            (
-                new_state.sigma * self.config.trego.d.0,
-                new_state.sigma * self.config.trego.d.1,
-            ),
+            multistarter,
         );
 
         problem.problem = Some(pb);
@@ -141,270 +170,5 @@ where
         new_state.prev_best_index = new_state.best_index;
         new_state.best_index = Some(new_best_index);
         new_state
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn compute_local_best_point(
-        &self,
-        obj_model: &dyn MixtureGpSurrogate,
-        cstr_models: &[Box<dyn MixtureGpSurrogate>],
-        cstr_funcs: &[impl CstrFn],
-        cstr_tols: &Array1<f64>,
-        lhs_optim_seed: Option<u64>,
-        infill_data: &InfillObjData<f64>,
-        current_best: (f64, Array1<f64>, Array1<f64>, Array1<f64>),
-        actives: &Array2<usize>,
-        xbest: &ArrayView1<f64>,
-        local_bounds: (f64, f64),
-    ) -> (f64, Array1<f64>) {
-        let mut infill_data = infill_data.clone();
-
-        let mut best_point = (current_best.0, current_best.1.to_owned());
-        let mut current_best_point = current_best.to_owned();
-
-        for (i, active) in actives.outer_iter().enumerate() {
-            let mut success = false;
-            let mut n_optim = 1;
-            let n_max_optim = 3;
-
-            let active = active.to_vec();
-            let obj = |x: &[f64],
-                       gradient: Option<&mut [f64]>,
-                       params: &mut InfillObjData<f64>|
-             -> f64 {
-                let InfillObjData {
-                    scale_infill_obj,
-                    scale_wb2,
-                    xbest: xcoop,
-                    fmin,
-                    ..
-                } = params;
-                let mut xcoop = xcoop.clone();
-                Self::setx(&mut xcoop, &active, x);
-
-                // Defensive programming NlOpt::Cobyla may pass NaNs
-                if xcoop.iter().any(|x| x.is_nan()) {
-                    return f64::INFINITY;
-                }
-
-                if let Some(grad) = gradient {
-                    // Use finite differences
-                    // let f = |x: &Vec<f64>| -> f64 {
-                    //     self.eval_infill_obj(x, obj_model, fmin, *scale_infill_obj, *scale_wb2)
-                    // };
-                    // grad[..].copy_from_slice(&x.to_vec().central_diff(&f));
-
-                    let g_infill_obj = if self.config.cstr_infill {
-                        self.eval_grad_infill_obj_with_cstrs(
-                            &xcoop,
-                            obj_model,
-                            cstr_models,
-                            cstr_tols,
-                            *fmin,
-                            *scale_infill_obj,
-                            *scale_wb2,
-                        )
-                    } else {
-                        self.eval_grad_infill_obj(
-                            &xcoop,
-                            obj_model,
-                            *fmin,
-                            *scale_infill_obj,
-                            *scale_wb2,
-                        )
-                    };
-                    let g_infill_obj = g_infill_obj
-                        .iter()
-                        .enumerate()
-                        .filter(|(i, _)| active.contains(i))
-                        .map(|(_, &g)| g)
-                        .collect::<Vec<_>>();
-                    grad[..].copy_from_slice(&g_infill_obj);
-                }
-                if self.config.cstr_infill {
-                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
-                        * pofs(&xcoop, cstr_models, &cstr_tols.to_vec())
-                } else {
-                    self.eval_infill_obj(&xcoop, obj_model, *fmin, *scale_infill_obj, *scale_wb2)
-                }
-            };
-
-            let cstrs: Vec<_> = if self.config.cstr_infill {
-                vec![]
-            } else {
-                (0..self.config.n_cstr)
-                    .map(|i| {
-                        let active = active.to_vec();
-                        let cstr = move |x: &[f64],
-                                         gradient: Option<&mut [f64]>,
-                                         params: &mut InfillObjData<f64>|
-                              -> f64 {
-                            let InfillObjData { xbest: xcoop, .. } = params;
-                            let mut xcoop = xcoop.clone();
-                            Self::setx(&mut xcoop, &active, x);
-
-                            let scale_cstr =
-                                params.scale_cstr.as_ref().expect("constraint scaling")[i];
-                            if self.config.cstr_strategy == ConstraintStrategy::MeanConstraint {
-                                Self::mean_cstr(
-                                    &*cstr_models[i],
-                                    &xcoop,
-                                    gradient,
-                                    scale_cstr,
-                                    &active,
-                                )
-                            } else {
-                                Self::upper_trust_bound_cstr(
-                                    &*cstr_models[i],
-                                    &xcoop,
-                                    gradient,
-                                    scale_cstr,
-                                    &active,
-                                )
-                            }
-                        };
-                        #[cfg(feature = "nlopt")]
-                        {
-                            Box::new(cstr) as Box<dyn nlopt::ObjFn<InfillObjData<f64>> + Sync>
-                        }
-                        #[cfg(not(feature = "nlopt"))]
-                        {
-                            Box::new(cstr)
-                                as Box<dyn crate::types::ObjFn<InfillObjData<f64>> + Sync>
-                        }
-                    })
-                    .collect()
-            };
-
-            // We merge metamodelized constraints and function constraints
-            let mut cstr_refs: Vec<_> = cstrs.iter().map(|c| c.as_ref()).collect();
-            let cstr_funcs = cstr_funcs
-                .iter()
-                .map(|cstr| cstr as &(dyn ObjFn<InfillObjData<f64>> + Sync))
-                .collect::<Vec<_>>();
-            cstr_refs.extend(cstr_funcs.clone());
-
-            // Limits
-            let xlimits = Self::getx(&self.xlimits, Axis(0), &active);
-            let xbest = Self::getx(&xbest.to_owned(), Axis(0), &active.to_vec());
-
-            let algorithm = match self.config.infill_optimizer {
-                InfillOptimizer::Slsqp => crate::optimizers::Algorithm::Slsqp,
-                InfillOptimizer::Cobyla => crate::optimizers::Algorithm::Cobyla,
-            };
-            if i == 0 {
-                info!("Optimize infill criterion...");
-            }
-            let mut rng = self.rng.clone();
-            while !success && n_optim <= n_max_optim {
-                let x_start = self.local_sampling(local_bounds, &xlimits, xbest.clone(), &mut rng);
-                let x_start_coop = Self::getx(&x_start, Axis(1), &active);
-
-                if let Some(seed) = lhs_optim_seed {
-                    let (y_opt, x_opt) =
-                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
-                            .cstr_tol(cstr_tols.to_owned())
-                            .seed(seed)
-                            .minimize();
-
-                    info!("LHS optimization best_x {}", x_opt);
-                    best_point = (y_opt, x_opt);
-                    success = true;
-                } else {
-                    let res = (0..self.config.n_start)
-                        .into_par_iter()
-                        .map(|i| {
-                            debug!("Begin optim {}", i);
-                            let optim_res =
-                                Optimizer::new(algorithm, &obj, &cstr_refs, &infill_data, &xlimits)
-                                    .xinit(&x_start_coop.row(i))
-                                    .max_eval((10 * x_start_coop.len()).min(MAX_EVAL_DEFAULT))
-                                    .ftol_rel(1e-4)
-                                    .ftol_abs(1e-4)
-                                    .minimize();
-                            debug!("End optim {}", i);
-                            optim_res
-                        })
-                        .reduce(
-                            || (f64::INFINITY, Array::ones((xlimits.nrows(),))),
-                            |a, b| if b.0 < a.0 { b } else { a },
-                        );
-
-                    if res.0.is_nan() || res.0.is_infinite() {
-                        success = false;
-                    } else {
-                        let mut xopt_coop = current_best_point.1.to_vec();
-                        Self::setx(&mut xopt_coop, &active, &res.1.to_vec());
-                        infill_data.xbest = xopt_coop.clone();
-                        let xopt_coop = Array1::from(xopt_coop);
-
-                        if crate::solver::coego::COEGO_IMPROVEMENT_CHECK {
-                            let (is_better, best) = self.is_objective_improved(
-                                &current_best_point,
-                                &xopt_coop,
-                                obj_model,
-                                cstr_models,
-                                cstr_tols,
-                                &cstr_funcs,
-                            );
-                            if is_better || i == 0 {
-                                if i > 0 {
-                                    info!(
-                                        "Partial infill criterion optim c={} has better result={} at x={}",
-                                        i, best.0, xopt_coop
-                                    );
-                                }
-                                best_point = (res.0, xopt_coop);
-                                current_best_point = best;
-                            }
-                        } else {
-                            best_point = (res.0, xopt_coop.to_owned());
-                            current_best_point =
-                                (res.0, xopt_coop, current_best_point.2, current_best_point.3);
-                        }
-                        success = true;
-                    }
-                }
-
-                if n_optim == n_max_optim && !success {
-                    log::warn!("All optimizations fail => Trigger LHS optimization");
-                    let (y_opt, x_opt) =
-                        Optimizer::new(Algorithm::Lhs, &obj, &cstr_refs, &infill_data, &xlimits)
-                            .minimize();
-
-                    info!("LHS optimization best_x {}", x_opt);
-                    best_point = (y_opt, x_opt);
-                    success = true;
-                }
-                n_optim += 1;
-            }
-        }
-        best_point
-    }
-
-    fn local_sampling(
-        &self,
-        local_bounds: (f64, f64),
-        xlimits: &ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>>,
-        xbest: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 1]>>,
-        rng: &mut Xoshiro256Plus,
-    ) -> Array2<f64> {
-        // Draw n_start initial points (multistart optim) in the local_area
-        // local_area = intersection(trust_region, xlimits)
-        let mut local_area = Array2::zeros((xlimits.nrows(), xlimits.ncols()));
-        Zip::from(local_area.rows_mut())
-            .and(&xbest)
-            .and(xlimits.rows())
-            .for_each(|mut row, xb, xlims| {
-                let (lo, up) = (
-                    xlims[0].max(xb - local_bounds.0),
-                    xlims[1].min(xb + local_bounds.1),
-                );
-                row.assign(&aview1(&[lo, up]))
-            });
-        let lhs = Lhs::new(&local_area)
-            .kind(egobox_doe::LhsKind::Maximin)
-            .with_rng(rng);
-        lhs.sample(self.config.n_start)
     }
 }


### PR DESCRIPTION
This PR factorizes code between TREGO and EGO iteration algorithm using a common new `optimize_infill_criterion` method replacing `compute_best_point` in EGO and `local_step` in TREGO.
Moreover EgorSolver API is simplified using config `seed` instead of `rng`. 
Trait bound `Clone` is removed from `Random` sampling protecting Rng access (to be consistent with LHS sampling).