### PR TITLE
Add a new Global Bounded Nelder-Mead infill criterion optimizer 

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -398,6 +398,31 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_xsinx_gbnm_optimizer_egor_builder() {
+        let outdir = "target/test_egor_builder_01";
+        let outfile = format!("{outdir}/{DOE_INITIAL_FILE}");
+        let _ = std::fs::remove_file(&outfile);
+        let initial_doe = array![[0.], [7.], [25.]];
+        let res = EgorBuilder::optimize(xsinx)
+            .configure(|cfg| {
+                cfg.infill_strategy(InfillStrategy::EI)
+                    .infill_optimizer(InfillOptimizer::Gbnm)
+                    .max_iters(30)
+                    .doe(&initial_doe)
+                    .target(-15.1)
+                    .outdir(outdir)
+            })
+            .min_within(&array![[0.0, 25.0]])
+            .run()
+            .expect("Egor should minimize xsinx");
+        let expected = array![-15.1];
+        assert_abs_diff_eq!(expected, res.y_opt, epsilon = 0.5);
+        let saved_doe: Array2<f64> = read_npy(&outfile).unwrap();
+        assert_abs_diff_eq!(initial_doe, saved_doe.slice(s![..3, ..1]), epsilon = 1e-6);
+    }
+
+    #[test]
+    #[serial]
     fn test_xsinx_with_domain_constraint() {
         let initial_doe = array![[0.], [7.], [10.]];
         let res = EgorBuilder::optimize(xsinx)

--- a/crates/ego/src/optimizers/gbnm/internal.rs
+++ b/crates/ego/src/optimizers/gbnm/internal.rs
@@ -17,6 +17,7 @@ pub struct GbnmOptions {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct GbnmResult {
     pub x: Array1<f64>,
     pub fval: f64,

--- a/crates/ego/src/optimizers/gbnm/internal.rs
+++ b/crates/ego/src/optimizers/gbnm/internal.rs
@@ -1,0 +1,407 @@
+/// GBNM implementation translated from <https://github.com/ojdo/gbnm>
+///
+use ndarray::{s, Array1, Array2, Axis};
+use ndarray_rand::*;
+
+#[derive(Debug, Clone)]
+pub struct GbnmOptions {
+    pub max_restarts: usize,
+    pub max_evals: usize,
+    pub n_points: usize,
+    pub max_iter: usize,
+    pub alpha: f64,
+    pub beta: f64,
+    pub gamma: f64,
+    pub epsilon: f64,
+    pub ssigma: f64,
+}
+
+#[derive(Debug)]
+pub struct GbnmResult {
+    pub x: Array1<f64>,
+    pub fval: f64,
+    pub used_points: Array2<f64>,
+    pub used_vals: Vec<f64>,
+    pub reason: Vec<String>,
+    pub n_eval: usize,
+}
+
+pub fn gbnm<F>(fun: &F, xmin: &Array1<f64>, xmax: &Array1<f64>, options: GbnmOptions) -> GbnmResult
+where
+    F: Fn(&Array1<f64>) -> f64,
+{
+    let ndim = xmin.len();
+    let xrange = xmax - xmin;
+
+    let mut n_eval = 0;
+    let mut used_points = Array2::zeros((ndim, 2 * options.max_restarts));
+    let mut used_vals = vec![f64::INFINITY; 2 * options.max_restarts];
+    let mut reason = vec!["".to_string(); options.max_restarts];
+
+    for i_restart in 0..options.max_restarts {
+        let initial_point = probabilistic_restart(&used_points, xmin, &xrange, options.n_points);
+        let a = (0.02 + 0.08 * rand::random::<f64>())
+            * xrange.iter().fold(f64::INFINITY, |a, &b| a.min(b));
+        let (mut splx, mut fval, evals) = init_simplex(&initial_point, a, fun, xmin, xmax);
+        n_eval += evals;
+
+        used_points
+            .slice_mut(s![.., 2 * i_restart])
+            .assign(&splx.column(0));
+        used_vals[2 * i_restart] = fval[0];
+        reason[i_restart] = "hit maxIter".into();
+
+        for _ in 0..options.max_iter {
+            let mut indices: Vec<_> = (0..=ndim).collect();
+            indices.sort_by(|&i, &j| fval[i].partial_cmp(&fval[j]).unwrap());
+            fval = indices.iter().map(|&i| fval[i]).collect();
+            splx = splx.select(Axis(1), &indices);
+
+            let x_worst = splx.column(ndim).to_owned();
+            let x_best = splx.column(0).to_owned();
+            let x_cent = splx.slice(s![.., ..ndim]).mean_axis(Axis(1)).unwrap();
+
+            if standard_deviation(&fval) < options.epsilon {
+                reason[i_restart] = "convergence (fVals similar)".into();
+                break;
+            }
+
+            if max_relative_diff(&splx, &xrange) < options.ssigma {
+                reason[i_restart] = "convergence (simplex small)".into();
+                break;
+            }
+
+            if n_eval >= options.max_evals {
+                reason[i_restart] = "hit maxEvals".into();
+                break;
+            }
+
+            let xr = clip(
+                &(x_cent.clone() + options.alpha * (&x_cent - &x_worst)),
+                xmin,
+                xmax,
+            );
+            let fr = fun(&xr);
+            n_eval += 1;
+
+            if fr < fval[0] {
+                let xe = clip(
+                    &(x_cent.clone() + options.gamma * (&xr - &x_cent)),
+                    xmin,
+                    xmax,
+                );
+                let fe = fun(&xe);
+                n_eval += 1;
+                if fe < fr {
+                    splx.slice_mut(s![.., ndim]).assign(&xe);
+                    fval[ndim] = fe;
+                } else {
+                    splx.slice_mut(s![.., ndim]).assign(&xr);
+                    fval[ndim] = fr;
+                }
+            } else if fr <= fval[ndim - 1] {
+                splx.slice_mut(s![.., ndim]).assign(&xr);
+                fval[ndim] = fr;
+            } else {
+                if fr < fval[ndim] {
+                    splx.slice_mut(s![.., ndim]).assign(&xr);
+                    fval[ndim] = fr;
+                }
+                let xc = x_cent.clone() + options.beta * (&x_worst - &x_cent);
+                let fc = fun(&xc);
+                n_eval += 1;
+
+                if fc > fval[ndim] {
+                    for (k, mut column) in splx.columns_mut().into_iter().enumerate().skip(1) {
+                        let xk = 0.5 * (&column + &x_best);
+                        let fk = fun(&xk);
+                        n_eval += 1;
+                        column.assign(&xk);
+                        fval[k] = fk;
+                    }
+                } else {
+                    splx.slice_mut(s![.., ndim]).assign(&xc);
+                    fval[ndim] = fc;
+                }
+            }
+        }
+
+        used_points
+            .slice_mut(s![.., 2 * i_restart + 1])
+            .assign(&splx.column(0));
+        used_vals[2 * i_restart + 1] = fval[0];
+        if n_eval >= options.max_evals {
+            reason[i_restart] = "hit maxEvals".into();
+            break;
+        }
+    }
+
+    let (min_idx, &min_val) = used_vals
+        .iter()
+        .enumerate()
+        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .unwrap();
+    let x = used_points.column(min_idx).to_owned();
+
+    GbnmResult {
+        x,
+        fval: min_val,
+        used_points,
+        used_vals,
+        reason,
+        n_eval,
+    }
+}
+
+fn probabilistic_restart(
+    used: &Array2<f64>,
+    xmin: &Array1<f64>,
+    xrange: &Array1<f64>,
+    n_points: usize,
+) -> Array1<f64> {
+    let ndim = xmin.len();
+    let mut best_prob = f64::INFINITY;
+    let mut best_point = xmin.clone();
+
+    for _ in 0..n_points {
+        let random_point =
+            xmin + &(xrange * &Array1::from_shape_fn(ndim, |_| rand::random::<f64>()));
+        let prob = gauss(&random_point, used, xrange);
+        if prob < best_prob {
+            best_prob = prob;
+            best_point = random_point;
+        }
+    }
+    best_point
+}
+
+fn init_simplex<F>(
+    x0: &Array1<f64>,
+    a: f64,
+    fun: F,
+    xmin: &Array1<f64>,
+    xmax: &Array1<f64>,
+) -> (Array2<f64>, Vec<f64>, usize)
+where
+    F: Fn(&Array1<f64>) -> f64,
+{
+    let ndim = x0.len();
+    let mut splx = Array2::<f64>::zeros((ndim, ndim + 1));
+    let mut fval = vec![0.0; ndim + 1];
+
+    let p = a * ((ndim as f64 + 1.0).sqrt() + ndim as f64 - 1.0) / (ndim as f64 * 2f64.sqrt());
+    let q = a * ((ndim as f64 + 1.0).sqrt() - 1.0) / (ndim as f64 * 2f64.sqrt());
+
+    splx.column_mut(0).assign(x0);
+
+    for k in 0..ndim {
+        splx.column_mut(k + 1).assign(x0);
+        splx[(k, k + 1)] += p;
+        for i in 0..ndim {
+            if i != k {
+                splx[(i, k + 1)] += q;
+            }
+        }
+        let mut col = splx.column_mut(k + 1);
+        col.zip_mut_with(xmin, |v, &min| *v = v.max(min));
+        col.zip_mut_with(xmax, |v, &max| *v = v.min(max));
+    }
+
+    let mut n_eval = 0;
+    for (k, column) in splx.columns().into_iter().enumerate() {
+        fval[k] = fun(&column.to_owned());
+        n_eval += 1;
+    }
+
+    (splx, fval, n_eval)
+}
+
+fn gauss(x: &Array1<f64>, points: &Array2<f64>, xrange: &Array1<f64>) -> f64 {
+    let glp = 0.01;
+    let sigma = Array1::from_iter(xrange.iter().map(|&r| glp * r * r));
+    let mut prob = 0.0;
+    for point in points.axis_iter(Axis(1)) {
+        if point.iter().all(|&v| v == 0.0) {
+            break;
+        }
+        let delta = x - &point;
+        let exp_term = delta
+            .iter()
+            .zip(sigma.iter())
+            .map(|(&d, &s)| d * d / s)
+            .sum::<f64>();
+        prob += (-0.5 * exp_term).exp();
+    }
+    prob
+}
+
+fn standard_deviation(values: &[f64]) -> f64 {
+    let mean = values.iter().copied().sum::<f64>() / values.len() as f64;
+    (values.iter().map(|&v| (v - mean).powi(2)).sum::<f64>() / values.len() as f64).sqrt()
+}
+
+fn max_relative_diff(splx: &Array2<f64>, xrange: &Array1<f64>) -> f64 {
+    let max_vals = splx.fold_axis(Axis(1), f64::MIN, |a, &b| a.max(b));
+    let min_vals = splx.fold_axis(Axis(1), f64::MAX, |a, &b| a.min(b));
+    max_vals
+        .iter()
+        .zip(min_vals.iter())
+        .zip(xrange.iter())
+        .map(|((&max, &min), &r)| (max - min) / r)
+        .fold(0.0, |a, b| a.max(b))
+}
+
+fn clip(x: &Array1<f64>, xmin: &Array1<f64>, xmax: &Array1<f64>) -> Array1<f64> {
+    x.iter()
+        .zip(xmin.iter())
+        .zip(xmax.iter())
+        .map(|((&v, &min), &max)| v.max(min).min(max))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+    use ndarray::{arr1, array};
+
+    #[test]
+    fn test_gbnm_minimization() {
+        // Example of using the Gbnm optimizer with a simple quadratic function
+        let fun = |x: &Array1<f64>| x.iter().map(|&xi| xi * xi).sum();
+
+        let xmin = arr1(&[-5.0, -5.0]);
+        let xmax = arr1(&[5.0, 5.0]);
+
+        let options = GbnmOptions {
+            max_restarts: 1,
+            max_evals: 100,
+            n_points: 10,
+            max_iter: 50,
+            alpha: 1.0,
+            beta: 0.5,
+            gamma: 2.0,
+            epsilon: 1e-6,
+            ssigma: 1e-6,
+        };
+
+        let result = gbnm(&fun, &xmin, &xmax, options);
+
+        let expected = array![0., 0.];
+        assert!(expected
+            .iter()
+            .zip(result.x.iter())
+            .all(|(a, b)| (a - b).abs() < 0.01)); // The solution should be near the origin
+        assert_abs_diff_eq!(result.fval, 0., epsilon = 1e-5); // We expect the minimum value to be near 0
+        assert_abs_diff_eq!(result.x, array![0., 0.], epsilon = 5e-3); // The minimum should be at (0, 0)
+    }
+
+    #[test]
+    fn test_gbnm_with_custom_function() {
+        // Example with a custom function to minimize
+        let fun = |x: &Array1<f64>| (x[0] - 2.0).powi(2) + (x[1] - 3.0).powi(2);
+
+        let xmin = arr1(&[-10.0, -10.0]);
+        let xmax = arr1(&[10.0, 10.0]);
+
+        let options = GbnmOptions {
+            max_restarts: 1,
+            max_evals: 100,
+            n_points: 10,
+            max_iter: 50,
+            alpha: 1.0,
+            beta: 0.5,
+            gamma: 2.0,
+            epsilon: 1e-6,
+            ssigma: 1e-6,
+        };
+
+        let result = gbnm(&fun, &xmin, &xmax, options);
+
+        assert_abs_diff_eq!(result.fval, 0., epsilon = 1e-5); // We expect the minimum value to be near 0
+        assert_abs_diff_eq!(result.x, array![2., 3.], epsilon = 5e-3); // The minimum should be at (2, 3)
+    }
+
+    #[test]
+    fn test_multiple_restarts() {
+        // Test with multiple restarts to verify different initializations
+        let fun = |x: &Array1<f64>| (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2);
+
+        let xmin = arr1(&[-5.0, -5.0]);
+        let xmax = arr1(&[5.0, 5.0]);
+
+        let options = GbnmOptions {
+            max_restarts: 3,
+            max_evals: 100,
+            n_points: 10,
+            max_iter: 50,
+            alpha: 1.0,
+            beta: 0.5,
+            gamma: 2.0,
+            epsilon: 1e-6,
+            ssigma: 1e-6,
+        };
+
+        let result = gbnm(&fun, &xmin, &xmax, options);
+
+        assert_abs_diff_eq!(result.fval, 0., epsilon = 1e-5); // We expect the minimum value to be near 0
+        assert_abs_diff_eq!(result.x, array![1., 2.], epsilon = 5e-3); // The minimum should be at (1, 2)
+    }
+
+    #[test]
+    fn test_max_evals() {
+        // Test hitting max evaluations limit
+        let fun = |x: &Array1<f64>| x.iter().map(|&xi| xi * xi).sum();
+
+        let xmin = arr1(&[-5.0, -5.0]);
+        let xmax = arr1(&[5.0, 5.0]);
+
+        let options = GbnmOptions {
+            max_restarts: 1,
+            max_evals: 10, // Set a small number to trigger max evaluations
+            n_points: 5,
+            max_iter: 50,
+            alpha: 1.0,
+            beta: 0.5,
+            gamma: 2.0,
+            epsilon: 1e-6,
+            ssigma: 1e-6,
+        };
+
+        let result = gbnm(&fun, &xmin, &xmax, options);
+
+        assert_eq!(result.reason[0], "hit maxEvals".to_string()); // We should hit the max evaluations limit
+    }
+
+    /// This function has a known minimum at (2,3)(2,3).
+    fn objective_function(x: &ndarray::Array1<f64>) -> f64 {
+        (x[0] - 2.0).powi(2) + (x[1] - 3.0).powi(2)
+    }
+
+    #[test]
+    fn test_main() {
+        let xmin = arr1(&[-5.0, -5.0]); // Lower bounds of the search space
+        let xmax = arr1(&[5.0, 5.0]); // Upper bounds of the search space
+
+        // Define the options for the optimizer
+        let options = GbnmOptions {
+            max_restarts: 3, // Number of restarts
+            max_evals: 100,  // Maximum evaluations per restart
+            n_points: 10,    // Number of points to sample for the initial simplex
+            max_iter: 50,    // Maximum iterations per restart
+            alpha: 1.0,      // Reflection coefficient
+            beta: 0.5,       // Contraction coefficient
+            gamma: 2.0,      // Expansion coefficient
+            epsilon: 1e-6,   // Convergence threshold based on function values
+            ssigma: 1e-6,    // Simplex size convergence threshold
+        };
+
+        // Run the optimization
+        let result = gbnm(&objective_function, &xmin, &xmax, options);
+
+        // Print the results
+        println!("Optimal x: {:?}", result.x);
+        println!("Optimal f(x): {}", result.fval);
+        println!("Reason for termination: {:?}", result.reason);
+    }
+}

--- a/crates/ego/src/optimizers/gbnm/mod.rs
+++ b/crates/ego/src/optimizers/gbnm/mod.rs
@@ -1,0 +1,82 @@
+//! Globalized bounded Nelder-Mead optimizer (Gbnm) - API
+
+mod internal;
+
+pub use internal::{GbnmOptions, gbnm};
+use ndarray::Array1;
+
+/// Options to control the optimizer
+#[derive(Debug, Clone)]
+pub struct Options {
+    pub max_restarts: usize,
+    pub max_evals: usize,
+    pub n_points: usize,
+    pub max_iter: usize,
+    pub alpha: f64,
+    pub beta: f64,
+    pub gamma: f64,
+    pub epsilon: f64,
+    pub ssigma: f64,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            max_restarts: 8,
+            max_evals: 5000,
+            n_points: 100,
+            max_iter: 300,
+            alpha: 1.0,
+            beta: 0.5,
+            gamma: 2.0,
+            epsilon: 1e-8,
+            ssigma: 1e-8,
+        }
+    }
+}
+
+/// Result returned by the optimizer
+#[derive(Debug)]
+pub struct Result {
+    pub x: Vec<f64>,
+    pub fval: f64,
+}
+
+/// Run the optimizer
+pub fn minimize<F>(
+    fun: F,
+    xmin: &[f64],
+    xmax: &[f64],
+    options: Options,
+) -> std::result::Result<Result, &'static str>
+where
+    F: Fn(&[f64]) -> f64,
+{
+    if xmin.len() != xmax.len() {
+        return Err("xmin and xmax must have the same length");
+    }
+
+    let xmin = Array1::from(xmin.to_vec());
+    let xmax = Array1::from(xmax.to_vec());
+
+    let wrapped_fun = |x: &Array1<f64>| fun(x.as_slice().unwrap());
+
+    let internal_options = GbnmOptions {
+        max_restarts: options.max_restarts,
+        max_evals: options.max_evals,
+        n_points: options.n_points,
+        max_iter: options.max_iter,
+        alpha: options.alpha,
+        beta: options.beta,
+        gamma: options.gamma,
+        epsilon: options.epsilon,
+        ssigma: options.ssigma,
+    };
+
+    let result = gbnm(&wrapped_fun, &xmin, &xmax, internal_options);
+
+    Ok(Result {
+        x: result.x.to_vec(),
+        fval: result.fval,
+    })
+}

--- a/crates/ego/src/optimizers/gbnm/mod.rs
+++ b/crates/ego/src/optimizers/gbnm/mod.rs
@@ -2,7 +2,7 @@
 
 mod internal;
 
-pub use internal::{GbnmOptions, gbnm};
+pub use internal::{gbnm, GbnmOptions};
 use ndarray::Array1;
 
 /// Options to control the optimizer
@@ -45,19 +45,20 @@ pub struct Result {
 /// Run the optimizer
 pub fn minimize<F>(
     fun: F,
-    xmin: &[f64],
-    xmax: &[f64],
+    bounds: &[(f64, f64)],
     options: Options,
 ) -> std::result::Result<Result, &'static str>
 where
     F: Fn(&[f64]) -> f64,
 {
-    if xmin.len() != xmax.len() {
-        return Err("xmin and xmax must have the same length");
+    if bounds.is_empty() {
+        return Err("Bounds cannot be empty");
     }
-
-    let xmin = Array1::from(xmin.to_vec());
-    let xmax = Array1::from(xmax.to_vec());
+    if bounds.len() != 2 {
+        return Err("Bounds must be a 2D array with shape (n, 2)");
+    }
+    let xmin: Array1<f64> = bounds.iter().map(|b| b.0).collect();
+    let xmax: Array1<f64> = bounds.iter().map(|b| b.1).collect();
 
     let wrapped_fun = |x: &Array1<f64>| fun(x.as_slice().unwrap());
 

--- a/crates/ego/src/optimizers/gbnm/mod.rs
+++ b/crates/ego/src/optimizers/gbnm/mod.rs
@@ -75,7 +75,6 @@ where
     };
 
     let result = gbnm(wrapped_fun, &xmin, &xmax, args.clone(), internal_options);
-    println!("Gbnm result: {:?}", result);
 
     Ok(Result {
         x: result.x.to_vec(),

--- a/crates/ego/src/optimizers/gbnm/mod.rs
+++ b/crates/ego/src/optimizers/gbnm/mod.rs
@@ -7,6 +7,9 @@ use ndarray::Array1;
 
 #[cfg(not(feature = "nlopt"))]
 use crate::types::ObjFn;
+#[cfg(feature = "nlopt")]
+use nlopt::ObjFn;
+
 use crate::InfillObjData;
 #[derive(Debug, Clone)]
 pub struct Options {

--- a/crates/ego/src/optimizers/mod.rs
+++ b/crates/ego/src/optimizers/mod.rs
@@ -1,5 +1,6 @@
 //! Optimizers used internally to optimize the infill criterion
 
+mod gbnm;
 mod optimizer;
 
 pub(crate) use optimizer::*;

--- a/crates/ego/src/optimizers/optimizer.rs
+++ b/crates/ego/src/optimizers/optimizer.rs
@@ -17,7 +17,7 @@ pub enum Algorithm {
     Gbnm,
 }
 
-pub const INFILL_MAX_EVAL_DEFAULT: usize = 1000;
+pub const INFILL_MAX_EVAL_DEFAULT: usize = 2000;
 
 /// Facade for various optimization algorithms
 pub(crate) struct Optimizer<'a> {

--- a/crates/ego/src/optimizers/optimizer.rs
+++ b/crates/ego/src/optimizers/optimizer.rs
@@ -226,11 +226,9 @@ impl<'a> Optimizer<'a> {
                     .map(|row| (row[0], row[1]))
                     .collect();
                 let res = gbnm::minimize(
-                    |x: &[f64]| {
-                        let mut u = InfillObjData::default();
-                        (self.fun)(x, None, &mut u)
-                    },
+                    self.fun,
                     &bounds,
+                    &mut self.user_data.clone(),
                     gbnm::Options {
                         max_evals: self.max_eval,
                         ..gbnm::Options::default()

--- a/crates/ego/src/optimizers/optimizer.rs
+++ b/crates/ego/src/optimizers/optimizer.rs
@@ -1,3 +1,4 @@
+use crate::optimizers::gbnm;
 use crate::InfillObjData;
 use ndarray::{arr1, Array1, Array2, ArrayView1};
 
@@ -13,6 +14,7 @@ use nlopt::ObjFn;
 pub enum Algorithm {
     Cobyla,
     Slsqp,
+    Gbnm,
 }
 
 pub const INFILL_MAX_EVAL_DEFAULT: usize = 1000;
@@ -216,6 +218,11 @@ impl<'a> Optimizer<'a> {
                         Err((_, x_opt, _)) => (f64::INFINITY, arr1(&x_opt)),
                     }
                 }
+            }
+            Algorithm::Gbnm => {
+                // gbnm::minimize(self.fun, &self.bounds, &self.cons, self.user_data);
+
+                todo!()
             }
         };
         log::debug!("... end optimization");

--- a/crates/ego/src/solver/solver_infill_optim.rs
+++ b/crates/ego/src/solver/solver_infill_optim.rs
@@ -177,6 +177,7 @@ where
             let algorithm = match self.config.infill_optimizer {
                 InfillOptimizer::Slsqp => crate::optimizers::Algorithm::Slsqp,
                 InfillOptimizer::Cobyla => crate::optimizers::Algorithm::Cobyla,
+                InfillOptimizer::Gbnm => crate::optimizers::Algorithm::Gbnm,
             };
 
             if i == 0 {

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -44,10 +44,13 @@ pub enum ConstraintStrategy {
 /// Optimizer used to optimize the infill criteria
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InfillOptimizer {
-    /// SLSQP optimizer (gradient from finite differences)
+    /// SLSQP optimizer (gradient based)
     Slsqp,
     /// Cobyla optimizer (gradient free)
     Cobyla,
+    /// GBNM optimizer (gradient free but do not handle constraints)
+    /// Use with constrained infill criterion in presence of constraints
+    Gbnm,
 }
 
 /// Strategy to choose several points at each iteration

--- a/crates/moe/src/algorithm.rs
+++ b/crates/moe/src/algorithm.rs
@@ -288,6 +288,7 @@ impl GpMixtureValidParams<f64> {
                     };
                 let mut expert_params = best_expert_params?;
                 expert_params.n_start(self.n_start());
+                expert_params.max_eval(self.max_eval());
                 expert_params.kpls_dim(self.kpls_dim());
                 if nc > 0 && self.theta_tunings().len() == 1 {
                     expert_params.theta_tuning(self.theta_tunings()[0].clone());

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -509,6 +509,7 @@ impl Egor {
         match self.infill_optimizer {
             InfillOptimizer::Cobyla => egobox_ego::InfillOptimizer::Cobyla,
             InfillOptimizer::Slsqp => egobox_ego::InfillOptimizer::Slsqp,
+            InfillOptimizer::Gbnm => egobox_ego::InfillOptimizer::Gbnm,
         }
     }
 

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -77,6 +77,7 @@ pub(crate) enum QInfillStrategy {
 pub(crate) enum InfillOptimizer {
     Cobyla = 1,
     Slsqp = 2,
+    Gbnm = 3,
 }
 
 #[pyclass]


### PR DESCRIPTION
This PR introduces the implementation of the Global Bounded Nelder-Mead algorithm as a new infill optimizer as described in [this paper](https://www.emse.fr/~leriche/gbnm_cas.pdf). 

This implementation in Rust is a transpilation of the Matlab found [here](https://github.com/ojdo/gbnm).

This algorithm can be activated with:
* Python: `egx.Egor(infill_optimizer=egx.InfillOptimizer.GBNM)`
* Rust: `EgorBuilder::optimize(...).configure(|cfg| cfg.infill_optimizer(InfillOptimizer::Gbnm))`
