### PR TITLE
Make CoEGO activity matrix more balanced

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -411,6 +411,7 @@ mod tests {
                     .doe(&initial_doe)
                     .target(-15.1)
                     .outdir(outdir)
+                    .seed(42)
             })
             .min_within(&array![[0.0, 25.0]])
             .run()

--- a/crates/ego/src/solver/coego.rs
+++ b/crates/ego/src/solver/coego.rs
@@ -55,27 +55,32 @@ where
     pub(crate) fn get_random_activity(&mut self, rng: &mut Xoshiro256Plus) -> Array2<usize> {
         let xdim = self.xlimits.nrows();
         let g_nb = self.config.coego.n_coop.min(xdim);
-        let g_size = xdim / g_nb + 1;
-
         let remainder = xdim % g_nb;
+        if remainder == 0 {
+            let g_size = xdim / g_nb;
+            let mut idx: Vec<usize> = (0..xdim).collect();
+            idx.shuffle(rng);
+            Array2::from_shape_vec((g_nb, g_size), idx.to_vec()).unwrap()
+        } else {
+            let g_size = xdim / g_nb + 1;
+            // When n_coop is not a diviser of xdim, indice is set to xdim
+            // (ie out of range) as to be filtered when handling last activity row
+            let mut idx: Vec<usize> = (0..xdim).collect();
+            idx.shuffle(rng);
+            let cut = g_nb * (g_size - 1);
+            let fill = Array::from_shape_vec((g_nb, g_size - 1), idx[..cut].to_vec()).unwrap();
+            let last_vals = Array1::from_vec(idx[cut..].to_vec());
 
-        // When n_coop is not a diviser of xdim, indice is set to xdim
-        // (ie out of range) as to be filtered when handling last activity row
-        let mut idx: Vec<usize> = (0..xdim).collect();
-        idx.shuffle(rng);
-        let cut = g_nb * (g_size - 1);
-        let fill = Array::from_shape_vec((g_nb, g_size - 1), idx[..cut].to_vec()).unwrap();
-        let last_vals = Array1::from_vec(idx[cut..].to_vec());
-
-        // Start with matrix of g_nb x g_size of <xdim> values
-        let mut indices = Array::from_elem((g_nb, g_size), xdim);
-        // Patch g_nb x (g_size - 1) indices
-        indices.slice_mut(s![.., ..(g_size - 1)]).assign(&fill);
-        // Patch last values in the last column
-        indices
-            .slice_mut(s![..remainder, g_size - 1])
-            .assign(&last_vals);
-        indices
+            // Start with matrix of g_nb x g_size of <xdim> values
+            let mut indices = Array::from_elem((g_nb, g_size), xdim);
+            // Patch g_nb x (g_size - 1) indices
+            indices.slice_mut(s![.., ..(g_size - 1)]).assign(&fill);
+            // Patch last values in the last column
+            indices
+                .slice_mut(s![..remainder, g_size - 1])
+                .assign(&last_vals);
+            indices
+        }
     }
 
     /// Returns activity when optimization is not partial, that is
@@ -226,18 +231,40 @@ mod tests {
     use crate::EgorSolver;
 
     #[test]
-    fn test_coego_activity() {
-        let xtypes = vec![XType::Cont(0., 1.); 123];
-        let config = EgorConfig::default().xtypes(&xtypes);
+    fn test_coego_activity_balanced() {
+        let dim = 125;
+        let ng = 5;
+        let xtypes = vec![XType::Cont(0., 1.); dim];
+        let config = EgorConfig::default()
+            .coego(crate::CoegoStatus::Enabled(ng))
+            .xtypes(&xtypes);
         let mut solver: EgorSolver<GpMixtureParams<f64>> = EgorSolver::new(config);
         let mut rng = Xoshiro256Plus::from_entropy();
         let activity = solver.get_random_activity(&mut rng);
-        assert_eq!(activity.nrows(), 5);
-        assert_eq!(activity.ncols(), 25);
-        assert_eq!(activity[[4, 24]], 123);
-        assert!(activity
-            .iter()
-            .enumerate()
-            .all(|(i, &v)| v < 124 || i == 124 || i == 99))
+        assert_eq!(activity.nrows(), ng);
+        let expected_ncols = 25;
+        assert_eq!(activity.ncols(), expected_ncols);
+        assert!(activity.iter().all(|&v| v < dim))
+    }
+
+    #[test]
+    fn test_coego_activity() {
+        let dim = 123;
+        let ng = 5;
+        let xtypes = vec![XType::Cont(0., 1.); dim];
+        let config = EgorConfig::default()
+            .coego(crate::CoegoStatus::Enabled(ng))
+            .xtypes(&xtypes);
+        let mut solver: EgorSolver<GpMixtureParams<f64>> = EgorSolver::new(config);
+        let mut rng = Xoshiro256Plus::from_entropy();
+        let activity = solver.get_random_activity(&mut rng);
+        assert_eq!(activity.nrows(), ng);
+        let expected_ncols = 25;
+        assert_eq!(activity.ncols(), expected_ncols);
+        assert_eq!(activity[[3, expected_ncols - 1]], dim);
+        assert_eq!(activity[[4, expected_ncols - 1]], dim);
+        assert!(activity.iter().enumerate().all(|(i, &v)| v < dim
+            || i == ng * expected_ncols - 1 // 124
+            || i == (ng - 1) * expected_ncols - 1)) // 99
     }
 }


### PR DESCRIPTION
Before when for instance x dimension is 124 and coego n_coop sets to 5, the activity matrix ends up being 6 x 24 with last row containing only 4 active components (ie 5 x 24 + 4 = 124). 

With this PR the activity matrix will be 5 x 25 with 24 active components in the last row (ie 4x25 + 24). It makes also the `n_coop` parameter truly the number of cooperative components 
