### PR TITLE
Improve multistart taking into account CoEGO activity

### DIFF
--- a/crates/ego/examples/mopta08.rs
+++ b/crates/ego/examples/mopta08.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use egobox_ego::{
-    CoegoStatus, EgorBuilder, GroupFunc, InfillOptimizer, InfillStrategy, QEiStrategy,
+    CoegoStatus, EgorBuilder, GroupFunc, HotStartMode, InfillOptimizer, InfillStrategy, QEiStrategy,
 };
 use egobox_moe::{CorrelationSpec, NbClusters, RegressionSpec};
 use ndarray::{s, Array1, Array2, ArrayView1, ArrayView2};
@@ -287,6 +287,7 @@ fn main() -> anyhow::Result<()> {
                 .outdir(outdir)
                 .warm_start(true)
                 .coego(CoegoStatus::Enabled(5))
+                .hot_start(HotStartMode::Enabled)
         })
         .min_within(&xlimits)
         .run()

--- a/crates/ego/src/solver/coego.rs
+++ b/crates/ego/src/solver/coego.rs
@@ -21,33 +21,33 @@ use nlopt::ObjFn;
 pub const COEGO_IMPROVEMENT_CHECK: bool = false;
 const CSTR_DOUBT: f64 = 3.;
 
+/// Set active components to xcoop using xopt values
+/// active may be longer than values
+pub(crate) fn set_active_x(xcoop: &mut [f64], active: &[usize], values: &[f64]) {
+    std::iter::zip(&active[..values.len()], values).for_each(|(&i, &xi)| xcoop[i] = xi)
+}
+
+/// Get active components from given ndarray following given axis
+/// active may contain out of range indices meaning it should be ignore
+pub(crate) fn get_active_x<A, D>(axis: Axis, xcoop: &Array<A, D>, active: &[usize]) -> Array<A, D>
+where
+    A: Clone,
+    D: RemoveAxis,
+{
+    let size = xcoop.len_of(axis);
+    let selection = active
+        .iter()
+        .filter(|&&i| i < size)
+        .cloned()
+        .collect::<Vec<usize>>();
+    xcoop.select(axis, &selection)
+}
+
 impl<SB, C> EgorSolver<SB, C>
 where
     SB: SurrogateBuilder + DeserializeOwned,
     C: CstrFn,
 {
-    /// Set active components to xcoop using xopt values
-    /// active may be longer than values
-    pub(crate) fn setx(xcoop: &mut [f64], active: &[usize], values: &[f64]) {
-        std::iter::zip(&active[..values.len()], values).for_each(|(&i, &xi)| xcoop[i] = xi)
-    }
-
-    /// Get active components from given ndarray following given axis
-    /// active may contain out of range indices meaning it should be ignore
-    pub(crate) fn getx<A, D>(xcoop: &Array<A, D>, axis: Axis, active: &[usize]) -> Array<A, D>
-    where
-        A: Clone,
-        D: RemoveAxis,
-    {
-        let size = xcoop.len_of(axis);
-        let selection = active
-            .iter()
-            .filter(|&&i| i < size)
-            .cloned()
-            .collect::<Vec<usize>>();
-        xcoop.select(axis, &selection)
-    }
-
     /// Compute array of components indices each row being used as
     /// active component during partial optimizations
     /// Array is (group nb, group size) where nb and size are computed

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -176,9 +176,6 @@ where
         } else {
             Xoshiro256Plus::from_entropy()
         };
-        let sampling = Lhs::new(&self.xlimits)
-            .with_rng(rng.clone())
-            .kind(LhsKind::Maximin);
 
         let hstart_doe: Option<Array2<f64>> =
             if self.config.warm_start && self.config.outdir.is_some() {
@@ -220,6 +217,9 @@ where
                 self.config.n_doe
             };
             info!("Compute initial LHS with {} points", n_doe);
+            let sampling = Lhs::new(&self.xlimits)
+                .with_rng(rng.clone())
+                .kind(LhsKind::Maximin);
             let x = sampling.sample(n_doe);
             (self.eval_obj(problem, &x), x)
         };
@@ -250,7 +250,7 @@ where
             .data((x_data, y_data.clone(), c_data.clone()))
             .clusterings(clusterings)
             .theta_inits(theta_inits)
-            .sampling(sampling);
+            .rng(rng);
 
         initial_state.doe_size = doe.nrows();
         initial_state.max_iters = self.config.max_iters as u64;
@@ -415,7 +415,7 @@ where
             info!(">>> TREGO local step");
             // Local step
             let models = self.refresh_surrogates(&new_state);
-            let infill_data = self.refresh_infill_data(problem, &new_state, &models);
+            let infill_data = self.refresh_infill_data(problem, &mut new_state, &models);
             let mut new_state = self.trego_step(problem, new_state, models, &infill_data);
             new_state.prev_step_ego = false;
             Ok((new_state, None))

--- a/crates/ego/src/solver/egor_state.rs
+++ b/crates/ego/src/solver/egor_state.rs
@@ -1,6 +1,5 @@
 /// Implementation of `argmin::IterState` for Egor optimizer
 use crate::{utils::find_best_result_index, InfillObjData};
-use egobox_doe::Lhs;
 use egobox_moe::Clustering;
 
 use argmin::core::{ArgminFloat, Problem, State, TerminationReason, TerminationStatus};
@@ -83,8 +82,6 @@ pub struct EgorState<F: Float> {
     pub prev_best_index: Option<usize>,
     /// index of best result in data
     pub best_index: Option<usize>,
-    /// Sampling method used to generate space filling samples
-    pub sampling: Option<Lhs<F, Xoshiro256Plus>>,
     /// Infill data used to optimized infill criterion
     pub infill_data: InfillObjData<F>,
 
@@ -236,19 +233,6 @@ where
         self.data.take()
     }
 
-    /// Set the sampling method used to draw random points
-    /// The sampling method is saved as part of the state to allow reproducible
-    /// optimization.   
-    pub fn sampling(mut self, sampling: Lhs<F, Xoshiro256Plus>) -> Self {
-        self.sampling = Some(sampling);
-        self
-    }
-
-    /// Moves the current sampling out and replaces it internally with `None`.
-    pub fn take_sampling(&mut self) -> Option<Lhs<F, Xoshiro256Plus>> {
-        self.sampling.take()
-    }
-
     /// Set the activity matrix  
     pub fn activity(mut self, activity: Array2<usize>) -> Self {
         self.activity = Some(activity);
@@ -398,7 +382,6 @@ where
             data: None,
             prev_best_index: None,
             best_index: None,
-            sampling: None,
             theta_inits: None,
             infill_data: Default::default(),
 

--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -3,36 +3,41 @@ use crate::gpmix::mixint::to_discrete_space;
 use crate::types::*;
 
 use crate::utils::{compute_cstr_scales, pofs, pofs_grad};
-use crate::EgorSolver;
+use crate::{solver::coego, EgorSolver};
 
 use argmin::core::{CostFunction, Problem};
 
-use egobox_doe::{Lhs, SamplingMethod};
+use egobox_doe::{Lhs, LhsKind, SamplingMethod};
 use egobox_moe::MixtureGpSurrogate;
 
 use log::{debug, info, warn};
 use ndarray::{s, Array, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, Ix1, Ix2, Zip};
 
+use ndarray_rand::rand::Rng;
 use ndarray_stats::QuantileExt;
 use rand_xoshiro::Xoshiro256Plus;
 use serde::de::DeserializeOwned;
 
 const CSTR_DOUBT: f64 = 3.;
 
-pub(crate) struct GlobalMultiStarter<'a> {
-    n_start: usize,
-    sampling: &'a Lhs<f64, Xoshiro256Plus>,
+pub(crate) struct GlobalMultiStarter<'a, R: Rng + Clone> {
+    xlimits: &'a Array2<f64>,
+    rng: R,
 }
 
-impl super::solver_infill_optim::MultiStarter for GlobalMultiStarter<'_> {
-    fn multistart(&self) -> Array2<f64> {
-        self.sampling.sample(self.n_start)
+impl<R: Rng + Clone> super::solver_infill_optim::MultiStarter for GlobalMultiStarter<'_, R> {
+    fn multistart(&mut self, n_start: usize, active: &[usize]) -> Array2<f64> {
+        let xlimits = coego::get_active_x(Axis(0), self.xlimits, active);
+        let sampling = Lhs::new(&xlimits)
+            .with_rng(&mut self.rng)
+            .kind(LhsKind::Maximin);
+        sampling.sample(n_start)
     }
 }
 
-impl<'a> GlobalMultiStarter<'a> {
-    pub fn new(n_start: usize, sampling: &'a Lhs<f64, Xoshiro256Plus>) -> Self {
-        GlobalMultiStarter { n_start, sampling }
+impl<'a, R: Rng + Clone> GlobalMultiStarter<'a, R> {
+    pub fn new(xlimits: &'a Array2<f64>, rng: R) -> Self {
+        GlobalMultiStarter { xlimits, rng }
     }
 }
 

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -141,7 +141,7 @@ class TestOptimizer(unittest.TestCase):
 
     def test_g24(self):
         n_doe = 5
-        max_iters = 20
+        max_iters = 30
         n_cstr = 2
         egor = egx.Egor(
             egx.to_specs([[0.0, 3.0], [0.0, 4.0]]),


### PR DESCRIPTION
This PR improves optim multistart:
* Use global rng instead of sampling 
* Remove sampling from EgorState
* Take into account activity when computing multistart initial points