### PR TITLE
Add naive LogEI infill criterion implementation for experimentation

### DIFF
--- a/crates/ego/src/criteria/mod.rs
+++ b/crates/ego/src/criteria/mod.rs
@@ -2,7 +2,7 @@
 mod ei;
 mod wb2;
 
-pub use ei::{ExpectedImprovement, EI};
+pub use ei::{ExpectedImprovement, LogExpectedImprovement, EI, LOG_EI};
 pub use wb2::{WB2Criterion, WB2, WB2S};
 
 use dyn_clonable::*;

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -410,7 +410,7 @@ mod tests {
         let initial_doe = array![[0.], [7.], [25.]];
         let res = EgorBuilder::optimize(xsinx)
             .configure(|cfg| {
-                cfg.infill_strategy(InfillStrategy::EI)
+                cfg.infill_strategy(InfillStrategy::LogEI)
                     .infill_optimizer(InfillOptimizer::Gbnm)
                     .max_iters(30)
                     .doe(&initial_doe)

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -236,6 +236,7 @@ impl EgorConfig {
     pub fn infill_strategy(mut self, infill: InfillStrategy) -> Self {
         self.infill_criterion = match infill {
             InfillStrategy::EI => Box::new(EI),
+            InfillStrategy::LogEI => Box::new(LOG_EI),
             InfillStrategy::WB2 => Box::new(WB2),
             InfillStrategy::WB2S => Box::new(WB2S),
         };

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -26,6 +26,8 @@ pub struct OptimResult<F: Float> {
 pub enum InfillStrategy {
     /// Expected Improvement
     EI,
+    /// Log of Expected Improvement
+    LogEI,
     /// Locating the regional extreme
     WB2,
     /// Scaled WB2

--- a/crates/ego/src/utils/cstr_pof.rs
+++ b/crates/ego/src/utils/cstr_pof.rs
@@ -132,6 +132,8 @@ mod tests {
 
         assert_abs_diff_eq!(grad[0], grad_central[0], epsilon = 1e-6);
 
+        // for Debugging purposes, we can save the values to npy files
+
         // let cx = Array1::linspace(0., 25., 100);
         // write_npy("cei_cx.npy", &cx).expect("save x");
 

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -7,6 +7,15 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
+def sphere(x: np.ndarray) -> np.ndarray:
+    """
+    Sphere function
+    Global optimum at x_opt = 0 with f_opt = 0
+    """
+    x = np.atleast_2d(x)
+    y = np.sum(x**2, axis=1).reshape(-1, 1)
+    print(f"obj={y} at {x}")
+    return y
 
 def xsinx(x: np.ndarray) -> np.ndarray:
     x = np.atleast_2d(x)
@@ -100,7 +109,18 @@ def six_humps(x):
     return np.atleast_2d(sum1).T
 
 
-class TestOptimizer(unittest.TestCase):
+class TestEgor(unittest.TestCase):
+
+    def test_sphere(self):
+        dim=5
+        egor = egx.Egor(egx.to_specs([[-5.12, 5.12]] * dim), 
+                        infill_strategy=egx.InfillStrategy.LOG_EI, 
+                        seed=42)
+        res = egor.minimize(sphere, max_iters=100)
+        print(f"Optimization f={res.y_opt} at {res.x_opt}")
+        self.assertAlmostEqual(0.0, res.y_opt[0], delta=1e-1)
+        np.testing.assert_allclose(0.0, res.x_opt, atol=2e-1)
+
     def test_xsinx(self):
         egor = egx.Egor(egx.to_specs([[0.0, 25.0]]), seed=42)
         res = egor.minimize(xsinx, max_iters=20)

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -7,6 +7,7 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
+
 def sphere(x: np.ndarray) -> np.ndarray:
     """
     Sphere function
@@ -16,6 +17,7 @@ def sphere(x: np.ndarray) -> np.ndarray:
     y = np.sum(x**2, axis=1).reshape(-1, 1)
     print(f"obj={y} at {x}")
     return y
+
 
 def xsinx(x: np.ndarray) -> np.ndarray:
     x = np.atleast_2d(x)
@@ -110,12 +112,13 @@ def six_humps(x):
 
 
 class TestEgor(unittest.TestCase):
-
     def test_sphere(self):
-        dim=5
-        egor = egx.Egor(egx.to_specs([[-5.12, 5.12]] * dim),
-                        infill_strategy=egx.InfillStrategy.LOG_EI,
-                        seed=42)
+        dim = 5
+        egor = egx.Egor(
+            egx.to_specs([[-5.12, 5.12]] * dim),
+            infill_strategy=egx.InfillStrategy.LOG_EI,
+            seed=42,
+        )
         res = egor.minimize(sphere, max_iters=100)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")
         self.assertAlmostEqual(0.0, res.y_opt[0], delta=1e-1)

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -113,8 +113,8 @@ class TestEgor(unittest.TestCase):
 
     def test_sphere(self):
         dim=5
-        egor = egx.Egor(egx.to_specs([[-5.12, 5.12]] * dim), 
-                        infill_strategy=egx.InfillStrategy.LOG_EI, 
+        egor = egx.Egor(egx.to_specs([[-5.12, 5.12]] * dim),
+                        infill_strategy=egx.InfillStrategy.LOG_EI,
                         seed=42)
         res = egor.minimize(sphere, max_iters=100)
         print(f"Optimization f={res.y_opt} at {res.x_opt}")

--- a/python/egobox/tests/test_gpmix.py
+++ b/python/egobox/tests/test_gpmix.py
@@ -87,7 +87,8 @@ class TestGpMix(unittest.TestCase):
     def test_kpls_griewank(self):
         lb = -600
         ub = 600
-        n_dim = 100
+        # n_dim = 100
+        n_dim = 50
         xlimits = [[ub, lb]] * n_dim
 
         # LHS training point generation
@@ -106,16 +107,17 @@ class TestGpMix(unittest.TestCase):
         # Surrogate model definition
         n_pls = 3
         builders = [
-            egx.Gpx.builder(),
-            egx.Gpx.builder(kpls_dim=n_pls),
+            egx.Gpx.builder(seed=42),
+            egx.Gpx.builder(kpls_dim=n_pls, seed=42),
         ]
 
         # Surrogate model fit & error estimation
         for builder in builders:
             gpx = builder.fit(x_train, y_train)
             y_pred = gpx.predict(x_test)
-            self.assertEqual(100, gpx.dims()[0])
+            self.assertEqual(n_dim, gpx.dims()[0])
             error = np.linalg.norm(y_pred - y_test) / np.linalg.norm(y_test)
+            self.assertAlmostEqual(0.1, error, delta=1e-1)
             print("   RMS error: " + str(error))
 
     def test_multi_outputs_exception(self):

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -486,6 +486,7 @@ impl Egor {
             InfillStrategy::Ei => egobox_ego::InfillStrategy::EI,
             InfillStrategy::Wb2 => egobox_ego::InfillStrategy::WB2,
             InfillStrategy::Wb2s => egobox_ego::InfillStrategy::WB2S,
+            InfillStrategy::LogEi => egobox_ego::InfillStrategy::LogEI,
         }
     }
 

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Recombination {
     /// prediction is taken from the expert with highest responsability
@@ -48,22 +48,23 @@ impl CorrelationSpec {
     pub(crate) const MATERN52: u8 = egobox_moe::CorrelationSpec::MATERN52.bits();
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum InfillStrategy {
     Ei = 1,
     Wb2 = 2,
     Wb2s = 3,
+    LogEi = 4,
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum ConstraintStrategy {
     Mc = 1,
     Utb = 2,
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum QInfillStrategy {
     Kb = 1,
@@ -72,7 +73,7 @@ pub(crate) enum QInfillStrategy {
     Clmin = 4,
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum InfillOptimizer {
     Cobyla = 1,
@@ -101,7 +102,7 @@ impl ExpectedOptimum {
     }
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum XType {
     Float = 1,
@@ -134,7 +135,7 @@ impl XSpec {
     }
 }
 
-#[pyclass(eq, eq_int, rename_all = "UPPERCASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum SparseMethod {
     Fitc = 1,


### PR DESCRIPTION
This PR introduces `InfillStrategy::LOG_EI` with the straightforward naive implementation. This is experimental, the related [paper](https://openreview.net/pdf?id=1vyAG6j9PE) points numerical issues and suggest an equivalent implementation more robust.