### PR TITLE
Change starting point strategy based on picking points in between training points

### DIFF
--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -21,13 +21,14 @@ use serde::de::DeserializeOwned;
 
 const CSTR_DOUBT: f64 = 3.;
 
+/// LocalMultiStarter is a multistart strategy that samples points in the xlimits.
 #[allow(dead_code)]
-pub(crate) struct GlobalMultiStarter<'a, R: Rng + Clone> {
+pub(crate) struct LhsMultiStarter<'a, R: Rng + Clone> {
     xlimits: &'a Array2<f64>,
     rng: R,
 }
 
-impl<R: Rng + Clone> super::solver_infill_optim::MultiStarter for GlobalMultiStarter<'_, R> {
+impl<R: Rng + Clone> super::solver_infill_optim::MultiStarter for LhsMultiStarter<'_, R> {
     fn multistart(&mut self, n_start: usize, active: &[usize]) -> Array2<f64> {
         let xlimits = coego::get_active_x(Axis(0), self.xlimits, active);
         let sampling = Lhs::new(&xlimits)
@@ -37,13 +38,16 @@ impl<R: Rng + Clone> super::solver_infill_optim::MultiStarter for GlobalMultiSta
     }
 }
 
-impl<'a, R: Rng + Clone> GlobalMultiStarter<'a, R> {
+impl<'a, R: Rng + Clone> LhsMultiStarter<'a, R> {
     #[allow(dead_code)]
     pub fn new(xlimits: &'a Array2<f64>, rng: R) -> Self {
-        GlobalMultiStarter { xlimits, rng }
+        LhsMultiStarter { xlimits, rng }
     }
 }
 
+/// MiddlePickerMultiStarter is a multistart strategy where starting points
+/// are picked in the area in between the training data points where
+/// infill criterion is expected to be high
 pub(crate) struct MiddlePickerMultiStarter<'a, 'b, R: Rng + Clone> {
     xlimits: &'a Array2<f64>,
     xtrain: &'b Array2<f64>,

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -2,12 +2,12 @@ use std::marker::PhantomData;
 
 use crate::errors::{EgoError, Result};
 use crate::gpmix::mixint::{as_continuous_limits, to_discrete_space};
+use crate::solver::solver_computations::MiddlePickerMultiStarter;
 use crate::utils::{find_best_result_index_from, update_data};
 use crate::{find_best_result_index, EgorConfig};
 use crate::{types::*, EgorState};
 use crate::{EgorSolver, DEFAULT_CSTR_TOL, MAX_POINT_ADDITION_RETRY};
 
-use super::solver_computations::GlobalMultiStarter;
 use argmin::argmin_error_closure;
 use argmin::core::{CostFunction, Problem, State};
 
@@ -636,7 +636,9 @@ where
                 .collect::<Vec<_>>();
 
             let sub_rng = Xoshiro256Plus::seed_from_u64(rng.gen());
-            let multistarter = GlobalMultiStarter::new(&self.xlimits, sub_rng);
+            // let multistarter = GlobalMultiStarter::new(&self.xlimits, sub_rng);
+            let xsamples = x_data.to_owned();
+            let multistarter = MiddlePickerMultiStarter::new(&self.xlimits, &xsamples, sub_rng);
 
             let (infill_obj, xk) = self.optimize_infill_criterion(
                 obj_model.as_ref(),

--- a/crates/ego/src/solver/solver_infill_optim.rs
+++ b/crates/ego/src/solver/solver_infill_optim.rs
@@ -190,8 +190,7 @@ where
             }
             while !success && n_optim <= n_max_optim {
                 let x_start = multistarter.multistart(self.config.n_start, &active);
-
-                let res = (0..self.config.n_start)
+                let res = (0..x_start.nrows())
                     .into_par_iter()
                     .map(|i| {
                         let optim_res = Optimizer::new(

--- a/crates/ego/src/solver/trego.rs
+++ b/crates/ego/src/solver/trego.rs
@@ -30,14 +30,14 @@ use super::solver_infill_optim::MultiStarter;
 
 /// LocalMultiStarter is a multistart strategy that samples points in the local area
 /// defined by the trust region and the xlimits.
-struct LocalMultiStarter<R: Rng + Clone> {
+struct LocalLhsMultiStarter<R: Rng + Clone> {
     xlimits: Array2<f64>,
     origin: Array1<f64>,
     local_bounds: (f64, f64),
     rng: R,
 }
 
-impl<R: Rng + Clone> LocalMultiStarter<R> {
+impl<R: Rng + Clone> LocalLhsMultiStarter<R> {
     fn new(xlimits: Array2<f64>, origin: Array1<f64>, local_bounds: (f64, f64), rng: R) -> Self {
         Self {
             xlimits,
@@ -48,7 +48,7 @@ impl<R: Rng + Clone> LocalMultiStarter<R> {
     }
 }
 
-impl<R: Rng + Clone> MultiStarter for LocalMultiStarter<R> {
+impl<R: Rng + Clone> MultiStarter for LocalLhsMultiStarter<R> {
     fn multistart(&mut self, n_start: usize, active: &[usize]) -> Array2<f64> {
         // Draw n_start initial points (multistart optim) in the local_area
         // local_area = intersection(trust_region, xlimits)
@@ -110,7 +110,7 @@ where
 
         let mut rng = new_state.take_rng().unwrap();
         let sub_rng = Xoshiro256Plus::seed_from_u64(rng.gen());
-        let multistarter = LocalMultiStarter::new(
+        let multistarter = LocalLhsMultiStarter::new(
             self.xlimits.clone(),
             xbest.to_owned(),
             (self.config.trego.d.0, self.config.trego.d.1),

--- a/crates/ego/src/utils/mod.rs
+++ b/crates/ego/src/utils/mod.rs
@@ -3,8 +3,10 @@ mod find_result;
 mod hot_start;
 mod misc;
 mod sort_axis;
+mod start_points;
 
 pub use cstr_pof::*;
 pub use find_result::*;
 pub use hot_start::*;
 pub use misc::*;
+pub use start_points::*;

--- a/crates/ego/src/utils/start_points.rs
+++ b/crates/ego/src/utils/start_points.rs
@@ -1,0 +1,132 @@
+use ndarray::{stack, Array1, Array2, Axis};
+use std::cmp::Ordering;
+
+pub fn start_points(x: &Array2<f64>, xl: &Array1<f64>, xu: &Array1<f64>) -> Array2<f64> {
+    let n = x.nrows();
+    let d = x.ncols();
+    let xrange = xu - xl;
+
+    // Collect all (i, j, distance) triplets
+    let mut pairs = Vec::new();
+    for i in 1..n {
+        for j in 0..i {
+            let diff = &x.row(i) - &x.row(j);
+            let scaled = &diff / &xrange;
+            let dist = scaled.dot(&scaled).sqrt();
+            pairs.push((i, j, dist));
+        }
+    }
+
+    // Sort pairs by distance
+    pairs.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(Ordering::Equal));
+
+    // Determine good midpoints
+    let mut xstart: Vec<Array1<f64>> = Vec::new();
+
+    for (i, j, _) in pairs {
+        // Consider xij middle of [xi, xj] to be a starting point
+        let xi = x.row(i);
+        let xj = x.row(j);
+        let xij = (xi.to_owned() + xj) / 2.0;
+
+        // Distance from xi (and xj)
+        let d_ij = ((xi.to_owned() - &xij) / &xrange)
+            .mapv(|v| v.powi(2))
+            .sum()
+            .sqrt();
+
+        // xij good to be added
+        let mut good = true;
+
+        // Discard xij if there is a training point xk closer than xi and xj from it
+        for k in 0..n {
+            if k != i && k != j {
+                let xk = x.row(k);
+                let d_k = ((&xk - &xij) / &xrange).mapv(|v| v.powi(2)).sum().sqrt();
+                if d_k < d_ij {
+                    good = false;
+                    break;
+                }
+            }
+        }
+
+        // Discard xij if there is already
+        for xk in &xstart {
+            let d_k = ((xk.to_owned() - &xij) / &xrange)
+                .mapv(|v| v.powi(2))
+                .sum()
+                .sqrt();
+            if d_k < d_ij {
+                good = false;
+                break;
+            }
+        }
+
+        if good {
+            xstart.push(xij);
+        }
+    }
+
+    if xstart.is_empty() {
+        Array2::<f64>::zeros((0, d))
+    } else {
+        let vstarts = xstart.iter().map(|p| p.view()).collect::<Vec<_>>();
+        stack(Axis(0), &vstarts).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
+    use rand_xoshiro::Xoshiro256Plus;
+
+    // #[test]
+    // fn test_no_start_points_when_too_close() {
+    //     let x = array![[0.0, 0.0], [0.01, 0.01]];
+    //     let xl = array![0.0, 0.0];
+    //     let xu = array![1.0, 1.0];
+
+    //     let result = start_points(&x, &xl, &xu);
+    //     assert_eq!(result.nrows(), 0); // Aucun point intermédiaire valide
+    // }
+
+    #[test]
+    fn test_midpoint_between_two_distant_points() {
+        let x = array![[0.1, 0.2], [0.9, 0.8]];
+        let xl = array![0.0, 0.0];
+        let xu = array![1.0, 1.0];
+
+        let result = start_points(&x, &xl, &xu);
+        assert_eq!(result.nrows(), 1);
+        assert_eq!(result.shape(), &[1, 2]);
+
+        let expected = array![[0.5, 0.5]];
+        assert!(result.abs_diff_eq(&expected, 1e-12));
+    }
+
+    #[test]
+    fn test_multiple_points() {
+        let x = array![[0.1, 0.2], [0.9, 0.2], [0.5, 0.8]];
+        let xl = array![0.0, 0.0];
+        let xu = array![1.0, 1.0];
+
+        let result = start_points(&x, &xl, &xu);
+        println!("result={}", result);
+        assert!(result.nrows() >= 1);
+    }
+
+    #[test]
+    fn test_n_start() {
+        for n in 1..50 {
+            let mut rng = Xoshiro256Plus::seed_from_u64(42);
+            let xt = Array2::random_using((n, 2), Uniform::new(0., 1.), &mut rng);
+            let xl = array![0.0, 0.0];
+            let xu = array![1.0, 1.0];
+
+            let result = start_points(&xt, &xl, &xu);
+            println!("n={} n_start={}", n, result.len());
+        }
+    }
+}

--- a/crates/ego/src/utils/start_points.rs
+++ b/crates/ego/src/utils/start_points.rs
@@ -82,16 +82,6 @@ mod tests {
     use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
     use rand_xoshiro::Xoshiro256Plus;
 
-    // #[test]
-    // fn test_no_start_points_when_too_close() {
-    //     let x = array![[0.0, 0.0], [0.01, 0.01]];
-    //     let xl = array![0.0, 0.0];
-    //     let xu = array![1.0, 1.0];
-
-    //     let result = start_points(&x, &xl, &xu);
-    //     assert_eq!(result.nrows(), 0); // Aucun point intermédiaire valide
-    // }
-
     #[test]
     fn test_midpoint_between_two_distant_points() {
         let x = array![[0.1, 0.2], [0.9, 0.8]];


### PR DESCRIPTION
This PR adds a new starting point strategy from D. Jones where starting points are picked in between training dataset points where the infill criterion is expected to be high (uncertainty is high as we are far from training data points). 
This new strategy replaces the old one based on simple LHS sampling.