### PR TITLE
Handle other constraint format (not only `c <= 0`)

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -113,14 +113,14 @@
 //! # fn g24(x: &ArrayView1<f64>) -> f64 { -x[0] - x[1] }
 //!
 //! // Constraints now return raw values (not necessarily <= 0)
-//! fn g24_c1_raw(x: &ArrayView1<f64>) -> f64 {
+//! fn g24_c1(x: &ArrayView1<f64>) -> f64 {
 //!     -2.0 * x[0].powf(4.0) + 8.0 * x[0].powf(3.0)
-//!     - 8.0 * x[0].powf(2.0) + x[1] - 2.0
+//!     - 8.0 * x[0].powf(2.0) + x[1]
 //! }
 //!
-//! fn g24_c2_raw(x: &ArrayView1<f64>) -> f64 {
+//! fn g24_c2(x: &ArrayView1<f64>) -> f64 {
 //!     -4.0 * x[0].powf(4.0) + 32.0 * x[0].powf(3.0)
-//!     - 88.0 * x[0].powf(2.0) + 96.0 * x[0] + x[1] - 36.0
+//!     - 88.0 * x[0].powf(2.0) + 96.0 * x[0] + x[1]
 //! }
 //!
 //! fn f_g24(x: &ArrayView2<f64>) -> Array2<f64> {
@@ -128,7 +128,7 @@
 //!     Zip::from(y.rows_mut())
 //!         .and(x.rows())
 //!         .for_each(|mut yi, xi| {
-//!             yi.assign(&array![g24(&xi), g24_c1_raw(&xi), g24_c2_raw(&xi)]);
+//!             yi.assign(&array![g24(&xi), g24_c1(&xi), g24_c2(&xi)]);
 //!         });
 //!     y
 //! }
@@ -137,8 +137,7 @@
 //! let doe = Lhs::new(&xlimits).sample(10);
 //! let res = EgorBuilder::optimize(f_g24).configure(|config|
 //!             config
-//!                 // Both constraints are c <= 0
-//!                 .cstr_specs(vec![CstrSpec::Leq(0.0), CstrSpec::Leq(0.0)])
+//!                 .cstr_specs(vec![CstrSpec::Leq(2.0), CstrSpec::Leq(36.0)])
 //!                 .infill_strategy(InfillStrategy::EI)
 //!                 .infill_optimizer(InfillOptimizer::Cobyla)
 //!                 .doe(&doe)

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -101,6 +101,55 @@
 //! println!("G24 min result = {:?}", res);
 //! ```
 //!
+//! ## Using constraint specifications
+//!
+//! Instead of requiring constraints to be formulated as `c <= 0`, you can specify
+//! constraint bounds directly using [`CstrSpec`]:
+//!
+//! ```no_run
+//! # use ndarray::{array, Array2, ArrayView1, ArrayView2, Zip};
+//! # use egobox_doe::{Lhs, SamplingMethod};
+//! # use egobox_ego::{EgorBuilder, InfillStrategy, InfillOptimizer, CstrSpec};
+//! # fn g24(x: &ArrayView1<f64>) -> f64 { -x[0] - x[1] }
+//!
+//! // Constraints now return raw values (not necessarily <= 0)
+//! fn g24_c1_raw(x: &ArrayView1<f64>) -> f64 {
+//!     -2.0 * x[0].powf(4.0) + 8.0 * x[0].powf(3.0)
+//!     - 8.0 * x[0].powf(2.0) + x[1] - 2.0
+//! }
+//!
+//! fn g24_c2_raw(x: &ArrayView1<f64>) -> f64 {
+//!     -4.0 * x[0].powf(4.0) + 32.0 * x[0].powf(3.0)
+//!     - 88.0 * x[0].powf(2.0) + 96.0 * x[0] + x[1] - 36.0
+//! }
+//!
+//! fn f_g24(x: &ArrayView2<f64>) -> Array2<f64> {
+//!     let mut y = Array2::zeros((x.nrows(), 3));
+//!     Zip::from(y.rows_mut())
+//!         .and(x.rows())
+//!         .for_each(|mut yi, xi| {
+//!             yi.assign(&array![g24(&xi), g24_c1_raw(&xi), g24_c2_raw(&xi)]);
+//!         });
+//!     y
+//! }
+//!
+//! let xlimits = array![[0., 3.], [0., 4.]];
+//! let doe = Lhs::new(&xlimits).sample(10);
+//! let res = EgorBuilder::optimize(f_g24).configure(|config|
+//!             config
+//!                 // Both constraints are c <= 0
+//!                 .cstr_specs(vec![CstrSpec::Leq(0.0), CstrSpec::Leq(0.0)])
+//!                 .infill_strategy(InfillStrategy::EI)
+//!                 .infill_optimizer(InfillOptimizer::Cobyla)
+//!                 .doe(&doe)
+//!                 .max_iters(40)
+//!                 .target(-5.5080))
+//!            .min_within(&xlimits)
+//!            .expect("optimizer configured")
+//!            .run()
+//!            .expect("g24 minimized");
+//! ```
+//!
 use crate::EgorConfig;
 use crate::EgorState;
 use crate::HotStartMode;

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -478,7 +478,6 @@ impl EgorConfig {
     /// so the number of GP surrogate models for constraints may be larger
     /// than the number of user-visible constraints.
     pub fn cstr_specs(mut self, specs: Vec<CstrSpec>) -> Self {
-        self.0.n_cstr = specs.len();
         self.0.cstr_specs = Some(specs);
         self
     }
@@ -740,6 +739,12 @@ impl EgorConfig {
     pub fn check(self) -> Result<ValidEgorConfig> {
         let mut config = self.0;
 
+        log::info!(
+            "n_cstr: {}, cstr_specs: {:?}",
+            config.n_cstr,
+            config.cstr_specs
+        );
+
         // When cstr_specs is set, derive internal n_cstr and validate
         if let Some(ref specs) = config.cstr_specs {
             // If n_cstr is set and does not match the number of specs, return an error
@@ -767,7 +772,7 @@ impl EgorConfig {
             )));
         }
 
-        // Fix theta tuning if n_statt is 0
+        // Fix theta tuning if n_start is 0
         if config.gp.n_start == 0 {
             log::info!(
                 "n_start is 0, setting theta value to {}",

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -742,6 +742,7 @@ impl EgorConfig {
 
         // When cstr_specs is set, derive internal n_cstr and validate
         if let Some(ref specs) = config.cstr_specs {
+            // If n_cstr is set and does not match the number of specs, return an error
             if config.n_cstr != specs.len() && config.n_cstr != 0 {
                 return Err(crate::EgoError::InvalidConfigError(format!(
                     "EgorConfig invalid: n_cstr ({}) does not match cstr_specs length ({}). \
@@ -754,14 +755,15 @@ impl EgorConfig {
         }
 
         // Check cstr_tol length if any
-        if config.n_cstr > 0
+        let n_eff_cstr = config.n_internal_cstr();
+        if n_eff_cstr > 0
             && let Some(cstr_tol) = config.cstr_tol.as_ref()
-            && cstr_tol.len() != config.n_cstr
+            && cstr_tol.len() != n_eff_cstr
         {
             return Err(crate::EgoError::InvalidConfigError(format!(
-                "EgorConfig invalid: cstr_tol length ({}) does not match n_cstr ({})",
+                "EgorConfig invalid: cstr_tol length ({}) does not match effective constraint count ({})",
                 cstr_tol.len(),
-                config.n_cstr
+                n_eff_cstr
             )));
         }
 

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -326,6 +326,11 @@ pub struct ValidEgorConfig {
     pub(crate) n_cstr: usize,
     /// Optional constraints violation tolerance meaning cstr < cstr_tol is considered valid
     pub(crate) cstr_tol: Option<Array1<f64>>,
+    /// Optional constraint specifications allowing to define how each constraint
+    /// should be interpreted (e.g. `c <= n`, `c >= n`, `c = n` or `n1 <= c <= n2`).
+    /// When set, `n_cstr` is derived from the number of specs.
+    /// Equal and Between specs expand into two internal `<= 0` constraints each.
+    pub(crate) cstr_specs: Option<Vec<CstrSpec>>,
     /// Initial doe can be either \[x\] with x inputs only or an evaluated doe \[x, y\]
     /// Note: x dimension is determined using `xlimits.nrows()`
     pub(crate) doe: Option<Array2<f64>>,
@@ -373,6 +378,7 @@ impl Default for ValidEgorConfig {
             n_doe: 0,
             n_cstr: 0,
             cstr_tol: None,
+            cstr_specs: None,
             doe: None,
             qei_config: QEiConfig::default(),
             gp: GpConfig::default(),
@@ -399,6 +405,18 @@ impl ValidEgorConfig {
     /// Check whether we are in a discrete optimization context
     pub fn discrete(&self) -> bool {
         crate::utils::discrete(&self.xtypes)
+    }
+
+    /// Returns the number of internal `<= 0` constraints after expanding `cstr_specs`.
+    ///
+    /// When `cstr_specs` is set, Equal and Between specs each expand to 2 internal constraints.
+    /// When `cstr_specs` is not set, this equals `n_cstr` (legacy behavior).
+    pub fn n_internal_cstr(&self) -> usize {
+        if let Some(ref specs) = self.cstr_specs {
+            crate::types::n_internal_cstrs(specs)
+        } else {
+            self.n_cstr
+        }
     }
 }
 
@@ -443,6 +461,25 @@ impl EgorConfig {
     /// Sets the tolerance on constraints violation (`cstr < tol`)
     pub fn cstr_tol(mut self, tol: Array1<f64>) -> Self {
         self.0.cstr_tol = Some(tol);
+        self
+    }
+
+    /// Sets constraint specifications allowing to define how each constraint
+    /// should be interpreted.
+    ///
+    /// When set, `n_cstr` is automatically derived from the number of specs.
+    /// Internally, all constraints are converted to `c' <= 0` form:
+    /// - `CstrSpec::Leq(n)`: `c <= n` → `c - n <= 0`
+    /// - `CstrSpec::Geq(n)`: `c >= n` → `n - c <= 0`
+    /// - `CstrSpec::Eq(n)`: `c = n` → two constraints: `c - n <= 0` and `n - c <= 0`
+    /// - `CstrSpec::Btw(lo, hi)`: `lo <= c <= hi` → two constraints: `lo - c <= 0` and `c - hi <= 0`
+    ///
+    /// Note: `Equal` and `Between` expand to two internal constraints each,
+    /// so the number of GP surrogate models for constraints may be larger
+    /// than the number of user-visible constraints.
+    pub fn cstr_specs(mut self, specs: Vec<CstrSpec>) -> Self {
+        self.0.n_cstr = specs.len();
+        self.0.cstr_specs = Some(specs);
         self
     }
 
@@ -702,6 +739,20 @@ impl EgorConfig {
     /// Checks and wraps an EgorConfig
     pub fn check(self) -> Result<ValidEgorConfig> {
         let mut config = self.0;
+
+        // When cstr_specs is set, derive internal n_cstr and validate
+        if let Some(ref specs) = config.cstr_specs {
+            if config.n_cstr != specs.len() && config.n_cstr != 0 {
+                return Err(crate::EgoError::InvalidConfigError(format!(
+                    "EgorConfig invalid: n_cstr ({}) does not match cstr_specs length ({}). \
+                     When using cstr_specs, n_cstr is derived automatically.",
+                    config.n_cstr,
+                    specs.len()
+                )));
+            }
+            config.n_cstr = specs.len();
+        }
+
         // Check cstr_tol length if any
         if config.n_cstr > 0
             && let Some(cstr_tol) = config.cstr_tol.as_ref()

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -234,6 +234,12 @@ where
             let x = sampling.sample(n_doe);
             (self.eval_obj(problem, &x), x)
         };
+        // Apply constraint transformation if cstr_specs are set
+        let y_data = if let Some(ref specs) = self.config.cstr_specs {
+            crate::types::transform_constraints(&y_data, specs)
+        } else {
+            y_data
+        };
         let doe = concatenate![Axis(1), x_data, y_data];
         if let Some(path) = self.config.outdir.as_ref() {
             std::fs::create_dir_all(path)?;
@@ -242,8 +248,9 @@ where
             write_npy(filepath, &doe).expect("Write initial doe");
         }
 
-        let clusterings = vec![None; self.config.n_cstr + 1];
-        let theta_inits = vec![None; self.config.n_cstr + 1];
+        let n_int_cstr = self.config.n_internal_cstr();
+        let clusterings = vec![None; n_int_cstr + 1];
+        let theta_inits = vec![None; n_int_cstr + 1];
         let no_point_added_retries = MAX_POINT_ADDITION_RETRY;
 
         let c_data = self.eval_problem_fcstrs(problem, &x_data);
@@ -278,7 +285,7 @@ where
         initial_state.max_iters = self.config.max_iters as u64;
         initial_state.doe.no_point_added_retries = no_point_added_retries;
         initial_state.doe.cstr_tol = self.config.cstr_tol.clone().unwrap_or(Array1::from_elem(
-            self.config.n_cstr + c_data.ncols(),
+            n_int_cstr + c_data.ncols(),
             DEFAULT_CSTR_TOL,
         ));
         initial_state.target_cost = self.config.target;

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -56,18 +56,28 @@ impl<SB: SurrogateBuilder + Serialize + DeserializeOwned, C: CstrFn> EgorSolver<
         x_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
         y_data: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Array2<f64> {
+        // Apply constraint transformation if cstr_specs are set
+        let y_data_owned;
+        let y_data: &ArrayBase<_, Ix2> = if let Some(ref specs) = self.config.cstr_specs {
+            y_data_owned = crate::types::transform_constraints(&y_data.to_owned(), specs);
+            &y_data_owned
+        } else {
+            y_data_owned = y_data.to_owned();
+            &y_data_owned
+        };
         let mut rng = if let Some(seed) = self.config.seed {
             Xoshiro256Plus::seed_from_u64(seed)
         } else {
             Xoshiro256Plus::from_entropy()
         };
-        let mut clusterings = vec![None; 1 + self.config.n_cstr];
-        let mut theta_tunings = vec![None; 1 + self.config.n_cstr];
+        let n_int_cstr = self.config.n_internal_cstr();
+        let mut clusterings = vec![None; 1 + n_int_cstr];
+        let mut theta_tunings = vec![None; 1 + n_int_cstr];
         let cstr_tol = self
             .config
             .cstr_tol
             .clone()
-            .unwrap_or(Array1::from_elem(self.config.n_cstr, DEFAULT_CSTR_TOL));
+            .unwrap_or(Array1::from_elem(n_int_cstr, DEFAULT_CSTR_TOL));
 
         // TODO: Manage fonction constraints
         let fcstrs = Vec::<Cstr>::new();
@@ -407,11 +417,10 @@ where
         let sampling = Lhs::new(&self.xlimits)
             .with_rng(sub_rng)
             .kind(LhsKind::Maximin);
-        let cstr_tol = self
-            .config
-            .cstr_tol
-            .clone()
-            .unwrap_or(Array1::from_elem(self.config.n_cstr, DEFAULT_CSTR_TOL));
+        let cstr_tol = self.config.cstr_tol.clone().unwrap_or(Array1::from_elem(
+            self.config.n_internal_cstr(),
+            DEFAULT_CSTR_TOL,
+        ));
         let (scale_infill_obj, scale_cstr, scale_fcstr, scale_wb2) = self.compute_scaling(
             &sampling,
             obj_model.as_ref(),
@@ -448,7 +457,7 @@ where
             &state.surrogate.data.as_ref().unwrap().0.nrows()
         );
 
-        (0..=self.config.n_cstr)
+        (0..=self.config.n_internal_cstr())
             .into_par_iter()
             .map(|k| {
                 let name = if k == 0 {
@@ -603,6 +612,12 @@ where
         };
 
         let y_actual = self.eval_obj(problem, &x_dat);
+        // Apply constraint transformation if cstr_specs are set
+        let y_actual = if let Some(ref specs) = self.config.cstr_specs {
+            crate::types::transform_constraints(&y_actual, specs)
+        } else {
+            y_actual
+        };
         let y_penalized = match self.config.failsafe_strategy {
             FailsafeStrategy::Imputation => Some(y_penalized),
             _ => None,
@@ -736,30 +751,34 @@ where
                 let actives = activity;
 
                 info!("Train surrogates with {} points...", xt.nrows());
-                let models_and_inits = (0..=self.config.n_cstr).into_par_iter().map(|k| {
-                    let name = if k == 0 {
-                        "Objective".to_string()
-                    } else {
-                        format!("Constraint[{k}]")
-                    };
-                    let do_clustering = ((init && i == 0) || recluster).into();
-                    let optimize_theta = ((iter as usize * self.config.qei_config.batch + i)
-                        .is_multiple_of(self.config.qei_config.optmod)
-                        && j == 0
-                        && !self.config.gp.theta_tuning.is_fixed())
-                    .into();
+                let models_and_inits =
+                    (0..=self.config.n_internal_cstr())
+                        .into_par_iter()
+                        .map(|k| {
+                            let name = if k == 0 {
+                                "Objective".to_string()
+                            } else {
+                                format!("Constraint[{k}]")
+                            };
+                            let do_clustering = ((init && i == 0) || recluster).into();
+                            let optimize_theta = ((iter as usize * self.config.qei_config.batch
+                                + i)
+                                .is_multiple_of(self.config.qei_config.optmod)
+                                && j == 0
+                                && !self.config.gp.theta_tuning.is_fixed())
+                            .into();
 
-                    self.make_clustered_surrogate(
-                        &name,
-                        &xt,
-                        &yt.slice(s![.., k]).to_owned(),
-                        do_clustering,
-                        optimize_theta,
-                        clusterings[k].as_ref(),
-                        theta_inits[k].as_ref(),
-                        actives,
-                    )
-                });
+                            self.make_clustered_surrogate(
+                                &name,
+                                &xt,
+                                &yt.slice(s![.., k]).to_owned(),
+                                do_clustering,
+                                optimize_theta,
+                                clusterings[k].as_ref(),
+                                theta_inits[k].as_ref(),
+                                actives,
+                            )
+                        });
                 let (models, inits): (Vec<_>, Vec<_>) = models_and_inits.unzip();
 
                 // Handle failsafe imputation on the first iteration
@@ -776,8 +795,10 @@ where
                                 "Impute failed initial points ({} points)...",
                                 xfail_points.nrows()
                             );
-                            let mut y_pen_imputed =
-                                Array2::zeros((xfail_points.nrows(), 1 + self.config.n_cstr));
+                            let mut y_pen_imputed = Array2::zeros((
+                                xfail_points.nrows(),
+                                1 + self.config.n_internal_cstr(),
+                            ));
                             Zip::from(y_pen_imputed.rows_mut())
                                 .and(xfail_points.rows())
                                 .for_each(|mut y_row, xfail| {
@@ -817,7 +838,7 @@ where
                     };
                 }
 
-                (0..=self.config.n_cstr).for_each(|k| {
+                (0..=self.config.n_internal_cstr()).for_each(|k| {
                     clusterings[k] = Some(models[k].to_clustering());
                     theta_inits[k] = Some(inits[k].to_owned());
                 });
@@ -933,7 +954,8 @@ where
 
                 match self.compute_virtual_point(&xk, y_data, obj_model.as_ref(), cstr_models) {
                     Ok(yk) => {
-                        let yk = Array2::from_shape_vec((1, 1 + self.config.n_cstr), yk).unwrap();
+                        let yk = Array2::from_shape_vec((1, 1 + self.config.n_internal_cstr()), yk)
+                            .unwrap();
                         y_dat = concatenate![Axis(0), y_dat, yk];
 
                         let yk_pen =

--- a/crates/ego/src/solver/solver_infill_optim.rs
+++ b/crates/ego/src/solver/solver_infill_optim.rs
@@ -176,7 +176,7 @@ where
                 // handle constraints metamodelized constraints
                 vec![]
             } else {
-                (0..self.config.n_cstr)
+                (0..self.config.n_internal_cstr())
                     .map(|i| {
                         let active = active.to_vec();
                         let cstr = move |x: &[f64],

--- a/crates/ego/src/solver/trego.rs
+++ b/crates/ego/src/solver/trego.rs
@@ -150,6 +150,12 @@ where
             && is_update_ok(&x_data, &x_new.row(0))
         {
             let y_new = self.eval_obj(problem, &x_new);
+            // Apply constraint transformation if cstr_specs are set
+            let y_new = if let Some(ref specs) = self.config.cstr_specs {
+                crate::types::transform_constraints(&y_new, specs)
+            } else {
+                y_new
+            };
 
             debug!("y_old-y_new={}", y_old - y_new[[0, 0]],);
             let c_new = self.eval_problem_fcstrs(problem, &x_new);

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -114,13 +114,13 @@ pub enum FailsafeStrategy {
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CstrSpec {
-    /// Constraint `c <= n`, transformed to `c - n <= 0`
+    /// Constraint `c <= Z`, transformed to `c - Z <= 0`
     Leq(f64),
-    /// Constraint `c >= n`, transformed to `n - c <= 0`
+    /// Constraint `c >= Z`, transformed to `Z - c <= 0`
     Geq(f64),
-    /// Constraint `c = n`, expanded to `c - n <= 0` AND `n - c <= 0`
+    /// Constraint `c = Z`, expanded to `c - Z <= 0` AND `Z - c <= 0`
     Eq(f64),
-    /// Constraint `lo <= c <= hi`, expanded to `lo - c <= 0` AND `c - hi <= 0`
+    /// Constraint `LO <= c <= HI`, expanded to `LO - c <= 0` AND `c - HI <= 0`
     Btw(f64, f64),
 }
 
@@ -136,9 +136,9 @@ impl CstrSpec {
     /// Transform a raw constraint value into internal `<= 0` constraint value(s)
     pub fn transform(&self, raw: f64) -> Vec<f64> {
         match self {
-            CstrSpec::Leq(n) => vec![raw - n],
-            CstrSpec::Geq(n) => vec![n - raw],
-            CstrSpec::Eq(n) => vec![raw - n, n - raw],
+            CstrSpec::Leq(z) => vec![raw - z],
+            CstrSpec::Geq(z) => vec![z - raw],
+            CstrSpec::Eq(z) => vec![raw - z, z - raw],
             CstrSpec::Btw(lo, hi) => vec![lo - raw, raw - hi],
         }
     }
@@ -158,8 +158,8 @@ pub fn n_internal_cstrs(specs: &[CstrSpec]) -> usize {
 /// columns have been transformed (and potentially expanded for Equal/Between specs).
 pub fn transform_constraints(y: &Array2<f64>, specs: &[CstrSpec]) -> Array2<f64> {
     let nrows = y.nrows();
-    let n_int = n_internal_cstrs(specs);
-    let mut result = Array2::zeros((nrows, 1 + n_int));
+    let n_intern = n_internal_cstrs(specs);
+    let mut result = Array2::zeros((nrows, 1 + n_intern));
 
     // Copy objective column
     result.column_mut(0).assign(&y.column(0));

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -84,6 +84,101 @@ pub enum FailsafeStrategy {
     Viability,
 }
 
+/// Constraint specification allowing the user to define how each constraint
+/// should be interpreted. Instead of requiring constraints to be formulated
+/// as `c <= 0`, users can specify bounds directly.
+///
+/// Internally, every specification is converted to one or more `c' <= 0`
+/// constraints before entering the optimization pipeline.
+///
+/// # Examples
+/// ```
+/// use egobox_ego::CstrSpec;
+///
+/// // c <= 5.0  ->  c - 5 <= 0
+/// let spec = CstrSpec::Leq(5.0);
+/// assert_eq!(spec.n_internal(), 1);
+/// assert_eq!(spec.transform(3.0), vec![-2.0]);
+///
+/// // c >= 2.0  ->  2 - c <= 0
+/// let spec = CstrSpec::Geq(2.0);
+/// assert_eq!(spec.transform(3.0), vec![-1.0]);
+///
+/// // c = 4.0  ->  c - 4 <= 0  AND  4 - c <= 0
+/// let spec = CstrSpec::Eq(4.0);
+/// assert_eq!(spec.n_internal(), 2);
+///
+/// // 1.0 <= c <= 3.0  ->  1 - c <= 0  AND  c - 3 <= 0
+/// let spec = CstrSpec::Btw(1.0, 3.0);
+/// assert_eq!(spec.n_internal(), 2);
+/// ```
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CstrSpec {
+    /// Constraint `c <= n`, transformed to `c - n <= 0`
+    Leq(f64),
+    /// Constraint `c >= n`, transformed to `n - c <= 0`
+    Geq(f64),
+    /// Constraint `c = n`, expanded to `c - n <= 0` AND `n - c <= 0`
+    Eq(f64),
+    /// Constraint `lo <= c <= hi`, expanded to `lo - c <= 0` AND `c - hi <= 0`
+    Btw(f64, f64),
+}
+
+impl CstrSpec {
+    /// Number of internal `<= 0` constraints this spec expands to
+    pub fn n_internal(&self) -> usize {
+        match self {
+            CstrSpec::Leq(_) | CstrSpec::Geq(_) => 1,
+            CstrSpec::Eq(_) | CstrSpec::Btw(_, _) => 2,
+        }
+    }
+
+    /// Transform a raw constraint value into internal `<= 0` constraint value(s)
+    pub fn transform(&self, raw: f64) -> Vec<f64> {
+        match self {
+            CstrSpec::Leq(n) => vec![raw - n],
+            CstrSpec::Geq(n) => vec![n - raw],
+            CstrSpec::Eq(n) => vec![raw - n, n - raw],
+            CstrSpec::Btw(lo, hi) => vec![lo - raw, raw - hi],
+        }
+    }
+}
+
+/// Compute the total number of internal constraints from a slice of [`CstrSpec`]
+pub fn n_internal_cstrs(specs: &[CstrSpec]) -> usize {
+    specs.iter().map(|s| s.n_internal()).sum()
+}
+
+/// Transform raw constraint columns in `y` according to `specs`.
+///
+/// Input `y` has shape `(nrows, 1 + n_user_cstrs)` where column 0 is the objective
+/// and columns `1..` are the raw user constraint values.
+///
+/// Returns a new array with shape `(nrows, 1 + n_internal_cstrs)` where the constraint
+/// columns have been transformed (and potentially expanded for Equal/Between specs).
+pub fn transform_constraints(y: &Array2<f64>, specs: &[CstrSpec]) -> Array2<f64> {
+    let nrows = y.nrows();
+    let n_int = n_internal_cstrs(specs);
+    let mut result = Array2::zeros((nrows, 1 + n_int));
+
+    // Copy objective column
+    result.column_mut(0).assign(&y.column(0));
+
+    // Transform constraint columns
+    for row_idx in 0..nrows {
+        let mut col = 1usize;
+        for (i, spec) in specs.iter().enumerate() {
+            let raw = y[[row_idx, 1 + i]];
+            let transformed = spec.transform(raw);
+            for v in &transformed {
+                result[[row_idx, col]] = *v;
+                col += 1;
+            }
+        }
+    }
+    result
+}
+
 /// A trait for types that can be returned by an objective function.
 ///
 /// This allows objective functions to return either `Array2<f64>` directly

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -138,15 +138,14 @@ def branin(x):
 BRANIN_CSTR_CONST = 0.2
 
 
-def branin_constraint(x, gradient=False):
+def branin_constrained(x):
     """
-    Constraint function: x1 * x2 - 0.2 >= 0
-    Returns positive value if constraint is violated.
+    Branin function with a constraint y*y >= 0.2
     """
-    if gradient:
-        return np.array([-x[1], -x[0]])
-    else:
-        return BRANIN_CSTR_CONST - x[0] * x[1]
+    x = np.atleast_2d(x)
+    obj = branin(x)
+    cstr = obj * obj
+    return np.hstack((obj, cstr.reshape(-1, 1)))
 
 
 class TestEgor(unittest.TestCase):
@@ -429,6 +428,24 @@ class TestEgor(unittest.TestCase):
         self.assertAlmostEqual(-5.5080, result.y_opt[0], delta=1e-2)
         self.assertAlmostEqual(2.3295, result.x_opt[0], delta=1e-2)
         self.assertAlmostEqual(3.1785, result.x_opt[1], delta=1e-2)
+
+    def test_branin_constrained(self):
+        xspecs = [[0.0, 1.0], [0.0, 1.0]]
+        egor = egx.Egor(
+            xspecs,
+            n_cstr=0,
+            cstr_specs=[egx.CstrSpec.geq(0.5)],
+            n_doe=15,
+        )
+        optim = egor.minimize(
+            branin_constrained,
+            max_iters=50,
+            seed=42,
+        )
+        print(
+            f"Optimum found at: x = {optim.result.x_opt}, f(x*) = {optim.result.y_opt[0]}"
+        )
+        self.assertAlmostEqual(0.707, optim.result.y_opt[0], delta=5e-1)
 
     def test_constrained_branin_with_nans(self):
         def branin_constrained_with_nans(x):

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -432,20 +432,18 @@ class TestEgor(unittest.TestCase):
     def test_branin_constrained(self):
         xspecs = [[0.0, 1.0], [0.0, 1.0]]
         egor = egx.Egor(
-            xspecs,
-            n_cstr=0,
-            cstr_specs=[egx.CstrSpec.geq(0.5)],
-            n_doe=15,
+            xspecs, cstr_specs=[egx.CstrSpec.geq(0.5)], n_doe=15, trego=True
         )
         optim = egor.minimize(
             branin_constrained,
-            max_iters=50,
+            max_iters=70,
             seed=42,
+            # verbose=egx.Verbose.INFO,
         )
         print(
             f"Optimum found at: x = {optim.result.x_opt}, f(x*) = {optim.result.y_opt[0]}"
         )
-        self.assertAlmostEqual(0.707, optim.result.y_opt[0], delta=5e-1)
+        self.assertAlmostEqual(0.707, optim.result.y_opt[0], delta=1e-1)
 
     def test_constrained_branin_with_nans(self):
         def branin_constrained_with_nans(x):

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -148,6 +148,7 @@ pub(crate) struct Egor {
     pub gp_config: GpConfig,
     pub n_cstr: usize,
     pub cstr_tol: Option<Vec<f64>>,
+    pub cstr_specs: Option<Vec<egobox_ego::CstrSpec>>,
     pub n_start: usize,
     pub n_doe: usize,
     pub doe: Option<Array2<f64>>,
@@ -176,6 +177,7 @@ impl Egor {
         gp_config = GpConfig::default(),
         n_cstr = 0,
         cstr_tol = None,
+        cstr_specs = None,
         n_start = 20,
         n_doe = 0,
         doe = None,
@@ -201,6 +203,7 @@ impl Egor {
         gp_config: GpConfig,
         n_cstr: usize,
         cstr_tol: Option<Vec<f64>>,
+        cstr_specs: Option<Vec<CstrSpec>>,
         n_start: usize,
         n_doe: usize,
         doe: Option<PyReadonlyArray2<f64>>,
@@ -290,6 +293,7 @@ impl Egor {
             gp_config,
             n_cstr,
             cstr_tol,
+            cstr_specs: cstr_specs.map(|specs| specs.into_iter().map(|s| s.inner).collect()),
             n_start,
             n_doe,
             doe,
@@ -748,7 +752,13 @@ impl Egor {
             .max_iters(max_iters.unwrap_or(1))
             .n_start(self.n_start)
             .n_doe(self.n_doe)
-            .cstr_tol(cstr_tol)
+            .cstr_tol(cstr_tol);
+
+        if let Some(ref cstr_specs) = self.cstr_specs {
+            config = config.cstr_specs(cstr_specs.clone());
+        }
+
+        let mut config = config
             .configure_gp(|gp| {
                 let regr = RegressionSpec(self.gp_config.regr_spec);
                 let corr = CorrelationSpec(self.gp_config.corr_spec);

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -751,8 +751,13 @@ impl Egor {
             .n_cstr(self.n_cstr)
             .max_iters(max_iters.unwrap_or(1))
             .n_start(self.n_start)
-            .n_doe(self.n_doe)
-            .cstr_tol(cstr_tol);
+            .n_doe(self.n_doe);
+
+        // Only set cstr_tol explicitly when user provided it or no cstr_specs is used.
+        // When cstr_specs is set without explicit cstr_tol, let Rust default it.
+        if self.cstr_tol.is_some() || self.cstr_specs.is_none() {
+            config = config.cstr_tol(cstr_tol);
+        }
 
         if let Some(ref cstr_specs) = self.cstr_specs {
             config = config.cstr_specs(cstr_specs.clone());

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -745,8 +745,6 @@ impl Egor {
             CoegoStatus::Enabled(self.coego_n_coop)
         };
 
-        let cstr_tol = self.cstr_tol(n_fcstr);
-
         let mut config = config
             .n_cstr(self.n_cstr)
             .max_iters(max_iters.unwrap_or(1))
@@ -756,6 +754,7 @@ impl Egor {
         // Only set cstr_tol explicitly when user provided it or no cstr_specs is used.
         // When cstr_specs is set without explicit cstr_tol, let Rust default it.
         if self.cstr_tol.is_some() || self.cstr_specs.is_none() {
+            let cstr_tol = self.cstr_tol(n_fcstr);
             config = config.cstr_tol(cstr_tol);
         }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -42,6 +42,7 @@ fn egobox(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ConstraintStrategy>()?;
     m.add_class::<QEiStrategy>()?;
     m.add_class::<FailsafeStrategy>()?;
+    m.add_class::<CstrSpec>()?;
     m.add_class::<Verbose>()?;
     m.add_class::<InfillOptimizer>()?;
     m.add_class::<XType>()?;

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -212,6 +212,77 @@ pub(crate) enum SparseMethod {
     Vfe = 2,
 }
 
+/// CstrSpec specifies how a constraint should be interpreted by the optimizer.
+///
+/// Instead of requiring constraints to be formulated as c <= 0,
+/// users can specify constraint bounds directly.
+///
+/// # Examples
+///
+/// ```python
+/// import egobox as egx
+///
+/// # c <= 5.0
+/// spec1 = egx.CstrSpec.leq(5.0)
+///
+/// # c >= 2.0
+/// spec2 = egx.CstrSpec.geq(2.0)
+///
+/// # c = 4.0 (equality constraint, expands to two internal constraints)
+/// spec3 = egx.CstrSpec.eq(4.0)
+///
+/// # 1.0 <= c <= 3.0 (double-sided, expands to two internal constraints)
+/// spec4 = egx.CstrSpec.btw(1.0, 3.0)
+/// ```
+#[gen_stub_pyclass]
+#[pyclass]
+#[derive(Debug, Clone)]
+pub(crate) struct CstrSpec {
+    pub(crate) inner: egobox_ego::CstrSpec,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl CstrSpec {
+    /// Constraint c <= bound, transformed to c - bound <= 0
+    #[staticmethod]
+    pub fn leq(bound: f64) -> Self {
+        CstrSpec {
+            inner: egobox_ego::CstrSpec::Leq(bound),
+        }
+    }
+
+    /// Constraint c >= bound, transformed to bound - c <= 0
+    #[staticmethod]
+    pub fn geq(bound: f64) -> Self {
+        CstrSpec {
+            inner: egobox_ego::CstrSpec::Geq(bound),
+        }
+    }
+
+    /// Equality constraint c = value, expands to two internal constraints:
+    /// c - value <= 0 and value - c <= 0
+    #[staticmethod]
+    pub fn eq(value: f64) -> Self {
+        CstrSpec {
+            inner: egobox_ego::CstrSpec::Eq(value),
+        }
+    }
+
+    /// Double-sided constraint lower <= c <= upper, expands to two internal constraints:
+    /// lower - c <= 0 and c - upper <= 0
+    #[staticmethod]
+    pub fn btw(lower: f64, upper: f64) -> Self {
+        CstrSpec {
+            inner: egobox_ego::CstrSpec::Btw(lower, upper),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{:?}", self.inner)
+    }
+}
+
 /// RunInfo contains information about a single run of the optimization algorithm,
 /// the name of the function being optimized and the run number (useful for logging and saving results).
 /// This is given by the user when calling the optimization function and is used for logging and saving results.


### PR DESCRIPTION
This PR introduces `cstr_specs` to allow the user to specify the kind of constraint he wants on a given constraint value. Till now by convention constraint were considered as being `c <= 0`. 

* Python: `egor = Egor(cstr_specs = [CstrSpec.leq(0), ...])`
* Rust: `egor_config.cstr_specs(vec![CstrSpec::Leq(0), ...])` 
with

| Constraint        | Python              | Rust                  |
|------------------|--------------------|-----------------------|
| <= C             | `CstrSpec.leq(C)`    | `CstrSpec::Leq(C)`      |
| >= C            | `CstrSPec.geq(C)`    | `CstrSpec::Geq(C)`     |
| == C            | `CstrSpec.eq(C)`    | `CstrSpec::Eq(C)`      |
| C1 <= c <= C2    | `CstrSpec.btw(C1, C2)`   | `CstrSpec::Btw(C1, C2)` |

Note: `cstr_specs` takes precedence over legacy option `n_cstr`