### PR TITLE
Fix Rust structures export for Python import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 0.38.0 - unreleased
 
+## Version 0.37.3 - 28/04/2026
+
+* Fix Rust structures export for Python import by @relf in <https://github.com/relf/EGObox/pull/421>
+
 ## Version 0.37.2 - 11/04/2026
 
 * Implement timeout feature by @relf in <https://github.com/relf/EGObox/pull/411>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "egobox"
-version = "0.37.2"
+version = "0.37.3"
 dependencies = [
  "argmin",
  "argmin_testfunctions",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egobox"
 authors.workspace = true
-version = "0.37.2"
+version = "0.37.3"
 license.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/python/egobox/tests/test_api.py
+++ b/python/egobox/tests/test_api.py
@@ -1,0 +1,75 @@
+import unittest
+
+
+class TestApiImports(unittest.TestCase):
+    def test_all_public_symbols_are_importable(self):
+        import egobox as egx
+        from egobox import (
+            ConstraintStrategy,
+            CorrelationSpec,
+            Egor,
+            EgorOptim,
+            ExitStatus,
+            FailsafeStrategy,
+            GpConfig,
+            GpMix,
+            Gpx,
+            InfillOptimizer,
+            InfillStrategy,
+            OptimResult,
+            QEiConfig,
+            QEiStrategy,
+            Recombination,
+            RegressionSpec,
+            RunInfo,
+            RunStatus,
+            Sampling,
+            SparseGpMix,
+            SparseGpx,
+            SparseMethod,
+            TregoConfig,
+            Verbose,
+            XSpec,
+            XType,
+            lhs,
+            sampling,
+        )
+
+        imported_symbols = {
+            "ConstraintStrategy": ConstraintStrategy,
+            "CorrelationSpec": CorrelationSpec,
+            "Egor": Egor,
+            "EgorOptim": EgorOptim,
+            "ExitStatus": ExitStatus,
+            "FailsafeStrategy": FailsafeStrategy,
+            "GpConfig": GpConfig,
+            "GpMix": GpMix,
+            "Gpx": Gpx,
+            "InfillOptimizer": InfillOptimizer,
+            "InfillStrategy": InfillStrategy,
+            "OptimResult": OptimResult,
+            "QEiConfig": QEiConfig,
+            "QEiStrategy": QEiStrategy,
+            "Recombination": Recombination,
+            "RegressionSpec": RegressionSpec,
+            "RunInfo": RunInfo,
+            "RunStatus": RunStatus,
+            "Sampling": Sampling,
+            "SparseGpMix": SparseGpMix,
+            "SparseGpx": SparseGpx,
+            "SparseMethod": SparseMethod,
+            "TregoConfig": TregoConfig,
+            "Verbose": Verbose,
+            "XSpec": XSpec,
+            "XType": XType,
+            "lhs": lhs,
+            "sampling": sampling,
+        }
+
+        for name, symbol in imported_symbols.items():
+            self.assertTrue(hasattr(egx, name), f"egobox is missing '{name}'")
+            self.assertIs(symbol, getattr(egx, name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -48,8 +48,11 @@ fn egobox(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<XType>()?;
     m.add_class::<XSpec>()?;
     m.add_class::<OptimResult>()?;
+    m.add_class::<EgorOptim>()?;
     m.add_class::<Recombination>()?;
     m.add_class::<RunInfo>()?;
+    m.add_class::<RunStatus>()?;
+    m.add_class::<ExitStatus>()?;
 
     // Surrogate Model
     m.add_class::<GpMix>()?;


### PR DESCRIPTION
This PR fixes forgotten Rust structures export as Python symbols: `RunStatus`, `ExitStatus` and `EgorOptim`