### PR TITLE
fixed docstrings inconsistencies

### DIFF
--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -455,28 +455,28 @@ class GpConfig:
         r"""
         ([nx] where nx is the dimension of inputs x)
         Initial guess for GP theta hyperparameters.
-        When None the default is 1e-2 for all components
+        When None the default is 1e-1 for all components
         """
     @theta_init.setter
     def theta_init(self, value: typing.Optional[typing.Sequence[builtins.float]]) -> None:
         r"""
         ([nx] where nx is the dimension of inputs x)
         Initial guess for GP theta hyperparameters.
-        When None the default is 1e-2 for all components
+        When None the default is 1e-1 for all components
         """
     @property
     def theta_bounds(self) -> typing.Optional[builtins.list[builtins.list[builtins.float]]]:
         r"""
         ([[lower_1, upper_1], ..., [lower_nx, upper_nx]] where nx is the dimension of inputs x)
         Space search when optimizing theta GP hyperparameters
-        When None the default is [1e-6, 1e2] for all components
+        When None the default is [1e-2, 1e1] for all components
         """
     @theta_bounds.setter
     def theta_bounds(self, value: typing.Optional[typing.Sequence[typing.Sequence[builtins.float]]]) -> None:
         r"""
         ([[lower_1, upper_1], ..., [lower_nx, upper_nx]] where nx is the dimension of inputs x)
         Space search when optimizing theta GP hyperparameters
-        When None the default is [1e-6, 1e2] for all components
+        When None the default is [1e-2, 1e1] for all components
         """
     @property
     def n_start(self) -> builtins.int:

--- a/python/src/gp_config.rs
+++ b/python/src/gp_config.rs
@@ -50,13 +50,13 @@ pub(crate) struct GpConfig {
 
     /// ([nx] where nx is the dimension of inputs x)
     ///   Initial guess for GP theta hyperparameters.
-    ///   When None the default is 1e-2 for all components
+    ///   When None the default is 1e-1 for all components
     #[pyo3(get, set)]
     pub theta_init: Option<Vec<f64>>,
 
     /// ([[lower_1, upper_1], ..., [lower_nx, upper_nx]] where nx is the dimension of inputs x)
     ///   Space search when optimizing theta GP hyperparameters
-    ///   When None the default is [1e-6, 1e2] for all components
+    ///   When None the default is [1e-2, 1e1] for all components
     #[pyo3(get, set)]
     pub theta_bounds: Option<Vec<Vec<f64>>>,
 


### PR DESCRIPTION
Fixed inconsistencies between code and docstring in the default values for `GpConfig.theta_init` and `GpConfig.theta_bounds`.

Closes #424 