### PR TITLE
Add fonction constraint specs handling

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -151,6 +151,7 @@
 //!
 use crate::EgorConfig;
 use crate::EgorState;
+use crate::EgoError;
 use crate::HotStartMode;
 use crate::errors::Result;
 use crate::types::*;
@@ -199,6 +200,7 @@ impl Default for RunInfo {
 pub struct EgorFactory<O: ObjFn, C: CstrFn = Cstr> {
     fobj: O,
     fcstrs: Vec<C>,
+    fcstr_specs: Option<Vec<CstrSpec>>,
     config: EgorConfig,
     run_info: RunInfo,
     verbose: Option<log::LevelFilter>,
@@ -214,6 +216,7 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
         EgorFactory {
             fobj,
             fcstrs: vec![],
+            fcstr_specs: None,
             config: EgorConfig::default(),
             run_info: RunInfo::default(),
             verbose: None,
@@ -231,7 +234,31 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
     /// arguments.
     pub fn subject_to(mut self, fcstrs: Vec<C>) -> Self {
         self.fcstrs = fcstrs;
+        self.fcstr_specs = None;
         self
+    }
+
+    /// Define function constraints and how each should be interpreted.
+    ///
+    /// `fcstr_specs` must contain one specification per function constraint.
+    /// Each specification can expand internally (e.g. `Eq` and `Btw`).
+    pub fn subject_to_with_specs(mut self, fcstrs: Vec<C>, fcstr_specs: Vec<CstrSpec>) -> Self {
+        self.fcstrs = fcstrs;
+        self.fcstr_specs = Some(fcstr_specs);
+        self
+    }
+
+    fn validate_fcstr_specs(&self) -> Result<()> {
+        if let Some(specs) = self.fcstr_specs.as_ref()
+            && specs.len() != self.fcstrs.len()
+        {
+            return Err(EgoError::InvalidConfigError(format!(
+                "fcstr_specs length ({}) does not match fcstrs length ({})",
+                specs.len(),
+                self.fcstrs.len()
+            )));
+        }
+        Ok(())
     }
 
     /// Set execution metadata used to qualify optimization run
@@ -258,9 +285,13 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
         xlimits: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     ) -> Result<Egor<O, C, GpMixtureParams<f64>>> {
         crate::utils::logging::init_logger(self.verbose);
+        self.validate_fcstr_specs()?;
         let config = self.config.xtypes(&to_xtypes(xlimits));
         Ok(Egor {
-            fobj: ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
+            fobj: match self.fcstr_specs {
+                Some(specs) => ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs),
+                None => ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
+            },
             solver: EgorSolver::new(config.check()?),
             run_info: self.run_info,
         })
@@ -274,9 +305,13 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
         xtypes: &[XType],
     ) -> Result<Egor<O, C, MixintGpMixtureParams>> {
         crate::utils::logging::init_logger(self.verbose);
+        self.validate_fcstr_specs()?;
         let config = self.config.xtypes(xtypes);
         Ok(Egor {
-            fobj: ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
+            fobj: match self.fcstr_specs {
+                Some(specs) => ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs),
+                None => ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
+            },
             solver: EgorSolver::new(config.check()?),
             run_info: self.run_info,
         })
@@ -1131,6 +1166,60 @@ mod tests {
         println!("G24 optim result = {res:?}");
         let expected = array![2.3295, 3.1785];
         assert_abs_diff_eq!(expected, res.x_opt, epsilon = 1e-1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_egor_g24_with_domain_constraints_specs() {
+        let xlimits = array![[0., 3.], [0., 4.]];
+        let doe = Lhs::new(&xlimits)
+            .with_rng(Xoshiro256Plus::seed_from_u64(42))
+            .sample(3);
+        let c1 = |x: &[f64], g: Option<&mut [f64]>, _u: &mut InfillObjData<f64>| {
+            if g.is_some() {
+                panic!("c1: gradient not implemented")
+            }
+            g24_c1(&Array1::from_vec(x.to_vec()))
+        };
+        let c2 = |x: &[f64], g: Option<&mut [f64]>, _u: &mut InfillObjData<f64>| {
+            if g.is_some() {
+                panic!("c2: gradient not implemented")
+            }
+            g24_c2(&Array1::from_vec(x.to_vec()))
+        };
+        let res = EgorBuilder::optimize(f_g24_bare)
+            .subject_to_with_specs(vec![c1, c2], vec![CstrSpec::Leq(0.0), CstrSpec::Leq(0.0)])
+            .configure(|config| {
+                config
+                    .doe(&doe)
+                    .max_iters(50)
+                    .infill_optimizer(InfillOptimizer::Cobyla)
+                    .seed(42)
+            })
+            .min_within(&xlimits)
+            .expect("Egor configured")
+            .run()
+            .expect("Minimize failure");
+        let expected = array![2.3295, 3.1785];
+        assert_abs_diff_eq!(expected, res.x_opt, epsilon = 1e-1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_subject_to_with_specs_length_mismatch() {
+        let xlimits = array![[0., 3.], [0., 4.]];
+        let c1 = |x: &[f64], _g: Option<&mut [f64]>, _u: &mut InfillObjData<f64>| {
+            g24_c1(&Array1::from_vec(x.to_vec()))
+        };
+        let c2 = |x: &[f64], _g: Option<&mut [f64]>, _u: &mut InfillObjData<f64>| {
+            g24_c2(&Array1::from_vec(x.to_vec()))
+        };
+
+        let res = EgorBuilder::optimize(f_g24_bare)
+            .subject_to_with_specs(vec![c1, c2], vec![CstrSpec::Leq(0.0)])
+            .min_within(&xlimits);
+
+        assert!(matches!(res, Err(EgoError::InvalidConfigError(_))));
     }
 
     #[test]

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -149,9 +149,9 @@
 //!            .expect("g24 minimized");
 //! ```
 //!
+use crate::EgoError;
 use crate::EgorConfig;
 use crate::EgorState;
-use crate::EgoError;
 use crate::HotStartMode;
 use crate::errors::Result;
 use crate::types::*;
@@ -289,7 +289,9 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
         let config = self.config.xtypes(&to_xtypes(xlimits));
         Ok(Egor {
             fobj: match self.fcstr_specs {
-                Some(specs) => ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs),
+                Some(specs) => {
+                    ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs)
+                }
                 None => ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
             },
             solver: EgorSolver::new(config.check()?),
@@ -309,7 +311,9 @@ impl<O: ObjFn, C: CstrFn> EgorFactory<O, C> {
         let config = self.config.xtypes(xtypes);
         Ok(Egor {
             fobj: match self.fcstr_specs {
-                Some(specs) => ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs),
+                Some(specs) => {
+                    ProblemFunc::new(self.fobj).subject_to_with_specs(self.fcstrs, specs)
+                }
                 None => ProblemFunc::new(self.fobj).subject_to(self.fcstrs),
             },
             solver: EgorSolver::new(config.check()?),

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -763,10 +763,10 @@ impl EgorConfig {
         let n_eff_cstr = config.n_internal_cstr();
         if n_eff_cstr > 0
             && let Some(cstr_tol) = config.cstr_tol.as_ref()
-            && cstr_tol.len() != n_eff_cstr
+            && cstr_tol.len() < n_eff_cstr
         {
             return Err(crate::EgoError::InvalidConfigError(format!(
-                "EgorConfig invalid: cstr_tol length ({}) does not match effective constraint count ({})",
+                "EgorConfig invalid: cstr_tol length ({}) is smaller than effective surrogate constraint count ({})",
                 cstr_tol.len(),
                 n_eff_cstr
             )));

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -296,7 +296,7 @@ where
             }
             if cstr_tol.len() < n_total_cstr {
                 let mut tol = cstr_tol.to_vec();
-                tol.extend(std::iter::repeat(DEFAULT_CSTR_TOL).take(n_total_cstr - cstr_tol.len()));
+                tol.extend(std::iter::repeat_n(DEFAULT_CSTR_TOL, n_total_cstr - cstr_tol.len()));
                 Array1::from_vec(tol)
             } else {
                 cstr_tol

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -296,7 +296,10 @@ where
             }
             if cstr_tol.len() < n_total_cstr {
                 let mut tol = cstr_tol.to_vec();
-                tol.extend(std::iter::repeat_n(DEFAULT_CSTR_TOL, n_total_cstr - cstr_tol.len()));
+                tol.extend(std::iter::repeat_n(
+                    DEFAULT_CSTR_TOL,
+                    n_total_cstr - cstr_tol.len(),
+                ));
                 Array1::from_vec(tol)
             } else {
                 cstr_tol

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -296,9 +296,7 @@ where
             }
             if cstr_tol.len() < n_total_cstr {
                 let mut tol = cstr_tol.to_vec();
-                tol.extend(
-                    std::iter::repeat(DEFAULT_CSTR_TOL).take(n_total_cstr - cstr_tol.len()),
-                );
+                tol.extend(std::iter::repeat(DEFAULT_CSTR_TOL).take(n_total_cstr - cstr_tol.len()));
                 Array1::from_vec(tol)
             } else {
                 cstr_tol

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -284,10 +284,28 @@ where
         initial_state.doe.doe_size = doe.nrows();
         initial_state.max_iters = self.config.max_iters as u64;
         initial_state.doe.no_point_added_retries = no_point_added_retries;
-        initial_state.doe.cstr_tol = self.config.cstr_tol.clone().unwrap_or(Array1::from_elem(
-            n_int_cstr + c_data.ncols(),
-            DEFAULT_CSTR_TOL,
-        ));
+        let n_total_cstr = n_int_cstr + c_data.ncols();
+        initial_state.doe.cstr_tol = if let Some(cstr_tol) = self.config.cstr_tol.clone() {
+            if cstr_tol.len() > n_total_cstr {
+                return Err(EgoError::InvalidConfigError(format!(
+                    "cstr_tol length ({}) is larger than total internal constraint count ({})",
+                    cstr_tol.len(),
+                    n_total_cstr
+                ))
+                .into());
+            }
+            if cstr_tol.len() < n_total_cstr {
+                let mut tol = cstr_tol.to_vec();
+                tol.extend(
+                    std::iter::repeat(DEFAULT_CSTR_TOL).take(n_total_cstr - cstr_tol.len()),
+                );
+                Array1::from_vec(tol)
+            } else {
+                cstr_tol
+            }
+        } else {
+            Array1::from_elem(n_total_cstr, DEFAULT_CSTR_TOL)
+        };
         initial_state.target_cost = self.config.target;
 
         let best_index = find_best_result_index(&y_data, &c_data, &initial_state.doe.cstr_tol);

--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -574,8 +574,14 @@ where
     ) -> Array2<f64> {
         let problem = pb.take_problem().unwrap();
         let fcstrs = problem.constraints();
+        let fcstr_specs = problem.constraint_specs();
 
         let res = self.eval_fcstrs(fcstrs, x);
+        let res = if let Some(specs) = fcstr_specs {
+            crate::types::transform_function_constraints(&res, specs)
+        } else {
+            res
+        };
 
         pb.problem = Some(problem);
         res

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -1097,11 +1097,9 @@ where
                     .kind(LhsKind::Maximin)
                     .with_rng(sub_rng);
 
-                let fcstr_mapping = crate::types::function_cstr_affine_mapping(
-                    cstr_funcs.len(),
-                    fcstr_specs,
-                )
-                .expect("validated function-constraint specs");
+                let fcstr_mapping =
+                    crate::types::function_cstr_affine_mapping(cstr_funcs.len(), fcstr_specs)
+                        .expect("validated function-constraint specs");
 
                 let transformed_fcstrs = fcstr_mapping
                     .iter()

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -83,6 +83,7 @@ impl<SB: SurrogateBuilder + Serialize + DeserializeOwned, C: CstrFn> EgorSolver<
 
         // TODO: Manage fonction constraints
         let fcstrs = Vec::<Cstr>::new();
+        let fcstr_specs = None;
         // TODO: c_data has to be passed as argument or better computed using fcstrs(x_data)
         let c_data = Array2::zeros((x_data.nrows(), 0));
         // TODO: Coego not implemented
@@ -105,6 +106,7 @@ impl<SB: SurrogateBuilder + Serialize + DeserializeOwned, C: CstrFn> EgorSolver<
             &cstr_tol,
             best_index,
             &fcstrs,
+            fcstr_specs,
             feasibility,
             &mut rng,
         );
@@ -412,6 +414,30 @@ where
 
         let pb = problem.take_problem().unwrap();
         let fcstrs = pb.constraints();
+        let fcstr_specs = pb.constraint_specs();
+
+        let fcstr_mapping = crate::types::function_cstr_affine_mapping(fcstrs.len(), fcstr_specs)
+            .expect("validated function-constraint specs");
+        let transformed_fcstrs = fcstr_mapping
+            .iter()
+            .map(|(raw_idx, affine_scale, affine_offset)| {
+                let cstr = fcstrs[*raw_idx].clone();
+                let affine_scale = *affine_scale;
+                let affine_offset = *affine_offset;
+                move |x: &[f64],
+                      gradient: Option<&mut [f64]>,
+                      params: &mut InfillObjData<f64>|
+                      -> f64 {
+                    if let Some(g) = gradient {
+                        let raw = cstr(x, Some(g), params);
+                        g.iter_mut().for_each(|v| *v *= affine_scale);
+                        affine_scale * raw + affine_offset
+                    } else {
+                        affine_scale * cstr(x, None, params) + affine_offset
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
 
         let mut rng = state.take_rng().unwrap();
         let sub_rng = Xoshiro256Plus::seed_from_u64(rng.r#gen());
@@ -428,7 +454,7 @@ where
             obj_model.as_ref(),
             cstr_models,
             &cstr_tol,
-            fcstrs,
+            &transformed_fcstrs,
             fmin,
             1., // FIXME: TREGO does not use sigma weighting portfolio
         );
@@ -713,6 +739,7 @@ where
             let init = new_state.get_iter() == 0;
             let pb = problem.take_problem().unwrap();
             let fcstrs = pb.constraints();
+            let fcstr_specs = pb.constraint_specs();
 
             let (x_dat, y_dat, c_dat, y_penalized, infill_value) = self.select_next_points(
                 init,
@@ -728,6 +755,7 @@ where
                 &state.doe.cstr_tol,
                 state.surrogate.best_index.unwrap(),
                 fcstrs,
+                fcstr_specs,
                 state.feasibility,
                 &mut rng,
             );
@@ -884,6 +912,7 @@ where
         cstr_tol: &Array1<f64>,
         best_index: usize,
         cstr_funcs: &[impl CstrFn],
+        fcstr_specs: Option<&[CstrSpec]>,
         feasibility: bool,
         rng: &mut Xoshiro256Plus,
     ) -> (Array2<f64>, Array2<f64>, Array2<f64>, Array2<f64>, f64) {
@@ -1068,12 +1097,39 @@ where
                     .kind(LhsKind::Maximin)
                     .with_rng(sub_rng);
 
+                let fcstr_mapping = crate::types::function_cstr_affine_mapping(
+                    cstr_funcs.len(),
+                    fcstr_specs,
+                )
+                .expect("validated function-constraint specs");
+
+                let transformed_fcstrs = fcstr_mapping
+                    .iter()
+                    .map(|(raw_idx, affine_scale, affine_offset)| {
+                        let cstr = cstr_funcs[*raw_idx].clone();
+                        let affine_scale = *affine_scale;
+                        let affine_offset = *affine_offset;
+                        move |x: &[f64],
+                              gradient: Option<&mut [f64]>,
+                              params: &mut InfillObjData<f64>|
+                              -> f64 {
+                            if let Some(g) = gradient {
+                                let raw = cstr(x, Some(g), params);
+                                g.iter_mut().for_each(|v| *v *= affine_scale);
+                                affine_scale * raw + affine_offset
+                            } else {
+                                affine_scale * cstr(x, None, params) + affine_offset
+                            }
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
                 let (scale_infill_obj, scale_cstr, scale_fcstr, scale_wb2) = self.compute_scaling(
                     &sampling,
                     obj_model.as_ref(),
                     cstr_models,
                     cstr_tol,
-                    cstr_funcs,
+                    &transformed_fcstrs,
                     fmin,
                     *sigma_weight,
                 );
@@ -1093,7 +1149,7 @@ where
                     sigma_weight: *sigma_weight,
                 };
 
-                let cstr_funcs = cstr_funcs
+                let cstr_funcs = transformed_fcstrs
                     .iter()
                     .enumerate()
                     .map(|(i, cstr)| {
@@ -1115,7 +1171,13 @@ where
                             } else {
                                 x
                             };
-                            cstr(x, gradient, params) / scale_fc
+                            if let Some(g) = gradient {
+                                let v = cstr(x, Some(g), params) / scale_fc;
+                                g.iter_mut().for_each(|gi| *gi /= scale_fc);
+                                v
+                            } else {
+                                cstr(x, None, params) / scale_fc
+                            }
                         }
                     })
                     .collect::<Vec<_>>();

--- a/crates/ego/src/solver/trego.rs
+++ b/crates/ego/src/solver/trego.rs
@@ -106,6 +106,29 @@ where
 
         let pb = problem.take_problem().unwrap();
         let fcstrs = pb.constraints();
+        let fcstr_specs = pb.constraint_specs();
+        let fcstr_mapping = crate::types::function_cstr_affine_mapping(fcstrs.len(), fcstr_specs)
+            .expect("validated function-constraint specs");
+        let transformed_fcstrs = fcstr_mapping
+            .iter()
+            .map(|(raw_idx, affine_scale, affine_offset)| {
+                let cstr = fcstrs[*raw_idx].clone();
+                let affine_scale = *affine_scale;
+                let affine_offset = *affine_offset;
+                move |x: &[f64],
+                      gradient: Option<&mut [f64]>,
+                      params: &mut InfillObjData<f64>|
+                      -> f64 {
+                    if let Some(g) = gradient {
+                        let raw = cstr(x, Some(g), params);
+                        g.iter_mut().for_each(|v| *v *= affine_scale);
+                        affine_scale * raw + affine_offset
+                    } else {
+                        affine_scale * cstr(x, None, params) + affine_offset
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
         // Optimize infill criterion
         let mut rng = new_state.take_rng().unwrap();
         let sub_rng = Xoshiro256Plus::seed_from_u64(rng.r#gen());
@@ -115,7 +138,7 @@ where
         let infill_optpb = InfillOptProblem {
             obj_model: obj_model.as_ref(),
             cstr_models,
-            cstr_funcs: fcstrs,
+            cstr_funcs: &transformed_fcstrs,
             cstr_tols: &cstr_tols,
             viability_model: None,
             infill_data,

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -98,11 +98,21 @@ pub enum FailsafeStrategy {
 /// // c <= 5.0  ->  c - 5 <= 0
 /// let spec = CstrSpec::Leq(5.0);
 /// assert_eq!(spec.n_internal(), 1);
-/// assert_eq!(spec.transform(3.0), vec![-2.0]);
+/// let transformed: Vec<f64> = spec
+///     .terms()
+///     .into_iter()
+///     .map(|(scale, offset)| scale * 3.0 + offset)
+///     .collect();
+/// assert_eq!(transformed, vec![-2.0]);
 ///
 /// // c >= 2.0  ->  2 - c <= 0
 /// let spec = CstrSpec::Geq(2.0);
-/// assert_eq!(spec.transform(3.0), vec![-1.0]);
+/// let transformed: Vec<f64> = spec
+///     .terms()
+///     .into_iter()
+///     .map(|(scale, offset)| scale * 3.0 + offset)
+///     .collect();
+/// assert_eq!(transformed, vec![-1.0]);
 ///
 /// // c = 4.0  ->  c - 4 <= 0  AND  4 - c <= 0
 /// let spec = CstrSpec::Eq(4.0);
@@ -133,13 +143,15 @@ impl CstrSpec {
         }
     }
 
-    /// Transform a raw constraint value into internal `<= 0` constraint value(s)
-    pub fn transform(&self, raw: f64) -> Vec<f64> {
+    /// Canonical internal affine terms as `(scale, offset)` pairs.
+    ///
+    /// Each internal constraint is `scale * raw + offset <= 0`.
+    pub fn terms(&self) -> Vec<(f64, f64)> {
         match self {
-            CstrSpec::Leq(z) => vec![raw - z],
-            CstrSpec::Geq(z) => vec![z - raw],
-            CstrSpec::Eq(z) => vec![raw - z, z - raw],
-            CstrSpec::Btw(lo, hi) => vec![lo - raw, raw - hi],
+            CstrSpec::Leq(z) => vec![(1.0, -z)],
+            CstrSpec::Geq(z) => vec![(-1.0, *z)],
+            CstrSpec::Eq(z) => vec![(1.0, -z), (-1.0, *z)],
+            CstrSpec::Btw(lo, hi) => vec![(-1.0, *lo), (1.0, -hi)],
         }
     }
 }
@@ -226,7 +238,11 @@ pub fn transform_constraints(y: &Array2<f64>, specs: &[CstrSpec]) -> Array2<f64>
         let mut col = 1usize;
         for (i, spec) in specs.iter().enumerate() {
             let raw = y[[row_idx, 1 + i]];
-            let transformed = spec.transform(raw);
+            let transformed = spec
+                .terms()
+                .into_iter()
+                .map(|(scale, offset)| scale * raw + offset)
+                .collect::<Vec<_>>();
             for v in &transformed {
                 result[[row_idx, col]] = *v;
                 col += 1;
@@ -234,6 +250,65 @@ pub fn transform_constraints(y: &Array2<f64>, specs: &[CstrSpec]) -> Array2<f64>
         }
     }
     result
+}
+
+/// Transform raw function-constraint columns in `c_data` according to `specs`.
+///
+/// Input `c_data` has shape `(nrows, n_user_fcstrs)` with one column per user
+/// function constraint. Output has shape `(nrows, n_internal_fcstrs)` where
+/// Equal/Between specs expand to two columns.
+pub fn transform_function_constraints(c_data: &Array2<f64>, specs: &[CstrSpec]) -> Array2<f64> {
+    let nrows = c_data.nrows();
+    let n_intern = n_internal_cstrs(specs);
+    let mut result = Array2::zeros((nrows, n_intern));
+
+    for row_idx in 0..nrows {
+        let mut col = 0usize;
+        for (i, spec) in specs.iter().enumerate() {
+            let raw = c_data[[row_idx, i]];
+            for v in spec
+                .terms()
+                .into_iter()
+                .map(|(scale, offset)| scale * raw + offset)
+            {
+                result[[row_idx, col]] = v;
+                col += 1;
+            }
+        }
+    }
+    result
+}
+
+/// Build affine expansion mapping for function constraints.
+///
+/// Returns tuples `(raw_index, scale, offset)` describing each internal function
+/// constraint as `scale * raw_fcstr[raw_index] + offset <= 0`.
+///
+/// If `specs` is `None`, legacy behavior is preserved with one identity mapping
+/// per function constraint.
+pub fn function_cstr_affine_mapping(
+    n_fcstrs: usize,
+    specs: Option<&[CstrSpec]>,
+) -> Result<Vec<(usize, f64, f64)>> {
+    match specs {
+        Some(specs) => {
+            if specs.len() != n_fcstrs {
+                return Err(EgoError::InvalidConfigError(format!(
+                    "fcstr_specs length ({}) does not match fcstrs length ({})",
+                    specs.len(),
+                    n_fcstrs
+                )));
+            }
+            let mut mapping = Vec::new();
+            for (idx, spec) in specs.iter().enumerate() {
+                for (scale, offset) in spec.terms() {
+                    mapping.push((idx, scale, offset));
+                }
+            }
+            Ok(mapping)
+        }
+        None => Ok((0..n_fcstrs).map(|idx| (idx, 1.0, 0.0)).collect()),
+    }
 }
 
 /// A trait for types that can be returned by an objective function.
@@ -283,7 +358,10 @@ where
 /// provided by the user and used by the internal optimizer
 pub trait Constraints<C: CstrFn> {
     /// Returns the list of constraints functions
-    fn constraints(&self) -> &[impl CstrFn];
+    fn constraints(&self) -> &[C];
+
+    /// Optional specifications for function constraints.
+    fn constraint_specs(&self) -> Option<&[CstrSpec]>;
 }
 
 /// As structure to handle the objective and constraints functions for implementing
@@ -292,6 +370,7 @@ pub trait Constraints<C: CstrFn> {
 pub struct ProblemFunc<O: ObjFn, C: CstrFn> {
     fobj: O,
     fcstrs: Vec<C>,
+    fcstr_specs: Option<Vec<CstrSpec>>,
 }
 
 impl<O: ObjFn, C: CstrFn> ProblemFunc<O, C> {
@@ -300,12 +379,21 @@ impl<O: ObjFn, C: CstrFn> ProblemFunc<O, C> {
         ProblemFunc {
             fobj,
             fcstrs: vec![],
+            fcstr_specs: None,
         }
     }
 
     /// Add constraints functions
     pub fn subject_to(mut self, fcstrs: Vec<C>) -> Self {
         self.fcstrs = fcstrs;
+        self.fcstr_specs = None;
+        self
+    }
+
+    /// Add constraints functions with corresponding constraint specifications.
+    pub fn subject_to_with_specs(mut self, fcstrs: Vec<C>, fcstr_specs: Vec<CstrSpec>) -> Self {
+        self.fcstrs = fcstrs;
+        self.fcstr_specs = Some(fcstr_specs);
         self
     }
 }
@@ -326,8 +414,12 @@ impl<O: ObjFn, C: CstrFn> CostFunction for ProblemFunc<O, C> {
 }
 
 impl<O: ObjFn, C: CstrFn> Constraints<C> for ProblemFunc<O, C> {
-    fn constraints(&self) -> &[impl CstrFn] {
+    fn constraints(&self) -> &[C] {
         &self.fcstrs
+    }
+
+    fn constraint_specs(&self) -> Option<&[CstrSpec]> {
+        self.fcstr_specs.as_deref()
     }
 }
 

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -129,6 +129,22 @@ class Egor:
             and `n_fcstr` the number of constraints passed as functions.
             When None, tolerances default to DEFAULT_CSTR_TOL=1e-4.
     
+        cstr_specs (list(n_cstr,) or None):
+            Optional list of CstrSpec objects describing how each surrogate-modeled
+            constraint (returned by `fun`) should be interpreted.
+            This allows users to define bounds directly instead of manually rewriting
+            constraints in `c <= 0` form:
+              * CstrSpec.leq(bound): c <= bound
+              * CstrSpec.geq(bound): c >= bound
+              * CstrSpec.eq(value): c == value (expands to two internal constraints)
+              * CstrSpec.btw(lower, upper): lower <= c <= upper
+                (expands to two internal constraints)
+    
+            When set, `n_cstr` is inferred from `len(cstr_specs)` (legacy `n_cstr`
+            value is ignored if set to zero, or must match otherwise).
+            If `cstr_tol` is explicitly provided, its length must match the total
+            number of internal constraints after expansion.
+    
         n_start (int > 0):
             Number of runs of infill strategy optimizations (best result taken)
     
@@ -237,14 +253,14 @@ class Egor:
                 to be made negative by the optimizer (which drives the input array "x").
                 Otherwise the function has to return the gradient (ndarray[nx,]) of the constraint function
                 wrt the "nx" components of "x".
-
+        
             fcstr_specs:
                 optional list of CstrSpec objects, one per fcstr, specifying how each function
                 constraint should be interpreted.
                 Length must be zero (legacy behavior) or equal to len(fcstrs).
                 This allows raw constraints not written as c <= 0, for example:
                 CstrSpec.leq(b), CstrSpec.geq(b), CstrSpec.eq(v), CstrSpec.btw(lo, hi).
-
+        
                 Note: CstrSpec.eq and CstrSpec.btw expand to two internal constraints each.
                 When cstr_tol is explicitly provided, ensure its size covers all internal
                 constraints: surrogate constraints + expanded function constraints.

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -214,7 +214,7 @@ class Egor:
         Egor object which can be used to optimize a function using the minimize method.
     """
     def __new__(cls, xspecs: typing.Any, gp_config: GpConfig = ..., n_cstr: builtins.int = 0, cstr_tol: typing.Optional[typing.Sequence[builtins.float]] = None, cstr_specs: typing.Optional[typing.Sequence[CstrSpec]] = None, n_start: builtins.int = 20, n_doe: builtins.int = 0, doe: typing.Optional[numpy.typing.NDArray[numpy.float64]] = None, infill_strategy: InfillStrategy = InfillStrategy.LOG_EI, cstr_infill: builtins.bool = False, cstr_strategy: ConstraintStrategy = ConstraintStrategy.MC, qei_config: QEiConfig = ..., infill_optimizer: InfillOptimizer = InfillOptimizer.COBYLA, trego: typing.Optional[typing.Any] = None, coego_n_coop: builtins.int = 0, target: builtins.float = -1.7976931348623157e+308, failsafe_strategy: FailsafeStrategy = FailsafeStrategy.REJECTION, seed: typing.Optional[builtins.int] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, verbose: typing.Optional[typing.Any] = None) -> Egor: ...
-    def minimize(self, fun: typing.Any, fcstrs: typing.Sequence[typing.Any] = [], max_iters: builtins.int = 20, run_info: typing.Optional[typing.Any] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, seed: typing.Optional[builtins.int] = None, timeout: typing.Optional[builtins.float] = None, verbose: typing.Optional[typing.Any] = None) -> EgorOptim:
+    def minimize(self, fun: typing.Any, fcstrs: typing.Sequence[typing.Any] = [], fcstr_specs: typing.Sequence[CstrSpec] = [], max_iters: builtins.int = 20, run_info: typing.Optional[typing.Any] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, seed: typing.Optional[builtins.int] = None, timeout: typing.Optional[builtins.float] = None, verbose: typing.Optional[typing.Any] = None) -> EgorOptim:
         r"""
         This function finds the minimum of a given function "fun"
         
@@ -237,6 +237,17 @@ class Egor:
                 to be made negative by the optimizer (which drives the input array "x").
                 Otherwise the function has to return the gradient (ndarray[nx,]) of the constraint function
                 wrt the "nx" components of "x".
+
+            fcstr_specs:
+                optional list of CstrSpec objects, one per fcstr, specifying how each function
+                constraint should be interpreted.
+                Length must be zero (legacy behavior) or equal to len(fcstrs).
+                This allows raw constraints not written as c <= 0, for example:
+                CstrSpec.leq(b), CstrSpec.geq(b), CstrSpec.eq(v), CstrSpec.btw(lo, hi).
+
+                Note: CstrSpec.eq and CstrSpec.btw expand to two internal constraints each.
+                When cstr_tol is explicitly provided, ensure its size covers all internal
+                constraints: surrogate constraints + expanded function constraints.
         
             max_iters:
                 the iteration budget, number of fun calls is "n_doe + q_batch * max_iters".

--- a/python/egobox/tests/test_egor.py
+++ b/python/egobox/tests/test_egor.py
@@ -386,6 +386,44 @@ class TestEgor(unittest.TestCase):
         self.assertEqual((n_doe + max_iters, 2), optim.result.x_doe.shape)
         self.assertEqual((n_doe + max_iters, 1), optim.result.y_doe.shape)
 
+    def test_g24_with_fcstrs_and_specs(self):
+        n_doe = 5
+        max_iters = 5
+        egor = egx.Egor(
+            [[0.0, 3.0], [0.0, 4.0]],
+            n_doe=n_doe,
+        )
+        start = time.process_time()
+        fcstrs = [g24_c1, g24_c2]
+        fcstr_specs = [egx.CstrSpec.leq(0.0), egx.CstrSpec.leq(0.0)]
+        optim = egor.minimize(
+            g24_bare,
+            max_iters=max_iters,
+            fcstrs=fcstrs,
+            fcstr_specs=fcstr_specs,
+            seed=42,
+        )
+        end = time.process_time()
+        print(
+            f"Optimization f={optim.result.y_opt} at {optim.result.x_opt} in {end - start}s"
+        )
+        self.assertAlmostEqual(-5.5080, optim.result.y_opt[0], delta=1e-2)
+        self.assertAlmostEqual(2.3295, optim.result.x_opt[0], delta=1e-2)
+        self.assertAlmostEqual(3.1785, optim.result.x_opt[1], delta=1e-2)
+
+    def test_fcstr_specs_length_mismatch(self):
+        egor = egx.Egor([[0.0, 3.0], [0.0, 4.0]], n_doe=5)
+        fcstrs = [g24_c1, g24_c2]
+        fcstr_specs = [egx.CstrSpec.leq(0.0)]
+        with self.assertRaises(ValueError):
+            _ = egor.minimize(
+                g24_bare,
+                max_iters=5,
+                fcstrs=fcstrs,
+                fcstr_specs=fcstr_specs,
+                seed=42,
+            )
+
     def test_g24_with_qei(self):
         n_doe = 5
         max_iters = 20

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -24,7 +24,7 @@ use egobox_gp::ThetaTuning;
 use egobox_moe::NbClusters;
 use ndarray::{Array1, Array2, ArrayView2, Axis, array, concatenate};
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray2, ToPyArray};
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBool;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
@@ -56,6 +56,22 @@ use std::cmp::Ordering;
 ///         list size should be equal to n_cstr + n_fctrs where n_cstr is the `n_cstr` argument
 ///         and `n_fcstr` the number of constraints passed as functions.
 ///         When None, tolerances default to DEFAULT_CSTR_TOL=1e-4.
+///
+///     cstr_specs (list(n_cstr,) or None):
+///         Optional list of CstrSpec objects describing how each surrogate-modeled
+///         constraint (returned by `fun`) should be interpreted.
+///         This allows users to define bounds directly instead of manually rewriting
+///         constraints in `c <= 0` form:
+///           * CstrSpec.leq(bound): c <= bound
+///           * CstrSpec.geq(bound): c >= bound
+///           * CstrSpec.eq(value): c == value (expands to two internal constraints)
+///           * CstrSpec.btw(lower, upper): lower <= c <= upper
+///             (expands to two internal constraints)
+///
+///         When set, `n_cstr` is inferred from `len(cstr_specs)` (legacy `n_cstr`
+///         value is ignored if set to zero, or must match otherwise).
+///         If `cstr_tol` is explicitly provided, its length must match the total
+///         number of internal constraints after expansion.
 ///
 ///     n_start (int > 0):
 ///         Number of runs of infill strategy optimizations (best result taken)
@@ -335,6 +351,17 @@ impl Egor {
     ///         Otherwise the function has to return the gradient (ndarray[nx,]) of the constraint function
     ///         wrt the "nx" components of "x".
     ///
+    ///     fcstr_specs:
+    ///         optional list of CstrSpec objects, one per fcstr, specifying how each function
+    ///         constraint should be interpreted.
+    ///         Length must be zero (legacy behavior) or equal to len(fcstrs).
+    ///         This allows raw constraints not written as c <= 0, for example:
+    ///         CstrSpec.leq(b), CstrSpec.geq(b), CstrSpec.eq(v), CstrSpec.btw(lo, hi).
+    ///
+    ///         Note: CstrSpec.eq and CstrSpec.btw expand to two internal constraints each.
+    ///         When cstr_tol is explicitly provided, ensure its size covers all internal
+    ///         constraints: surrogate constraints + expanded function constraints.
+    ///
     ///     max_iters:
     ///         the iteration budget, number of fun calls is "n_doe + q_batch * max_iters".
     ///
@@ -382,13 +409,14 @@ impl Egor {
     ///         x_opt (array[1, nx]): x value where fun is at its minimum subject to constraints
     ///         y_opt (array[1, nx]): fun(x_opt)
     ///
-    #[pyo3(signature = (fun, fcstrs=vec![], max_iters = 20, run_info = None, outdir = None, warm_start = false, hot_start = None, seed = None, timeout = None, verbose = None))]
+    #[pyo3(signature = (fun, fcstrs=vec![], fcstr_specs=vec![], max_iters = 20, run_info = None, outdir = None, warm_start = false, hot_start = None, seed = None, timeout = None, verbose = None))]
     #[allow(clippy::too_many_arguments)]
     fn minimize(
         &self,
         py: Python,
         fun: Py<PyAny>,
         fcstrs: Vec<Py<PyAny>>,
+        fcstr_specs: Vec<CstrSpec>,
         max_iters: usize,
         run_info: Option<Py<PyAny>>,
         outdir: Option<String>,
@@ -427,6 +455,19 @@ impl Egor {
         };
 
         let n_fcstr = fcstrs.len();
+        if !fcstr_specs.is_empty() && fcstr_specs.len() != n_fcstr {
+            return Err(PyValueError::new_err(format!(
+                "fcstr_specs length ({}) must match fcstrs length ({})",
+                fcstr_specs.len(),
+                n_fcstr
+            )));
+        }
+
+        let fcstr_specs = fcstr_specs
+            .into_iter()
+            .map(|spec| spec.inner)
+            .collect::<Vec<_>>();
+
         let fcstrs = fcstrs
             .iter()
             .map(|cstr| {
@@ -445,8 +486,14 @@ impl Egor {
             })
             .collect::<Vec<_>>();
 
-        let mixintegor = egobox_ego::EgorFactory::optimize(obj)
-            .subject_to(fcstrs)
+        let factory = egobox_ego::EgorFactory::optimize(obj);
+        let factory = if fcstr_specs.is_empty() {
+            factory.subject_to(fcstrs)
+        } else {
+            factory.subject_to_with_specs(fcstrs, fcstr_specs)
+        };
+
+        let mixintegor = factory
             .configure(|config| {
                 self.apply_config(
                     config,
@@ -751,9 +798,10 @@ impl Egor {
             .n_start(self.n_start)
             .n_doe(self.n_doe);
 
-        // Only set cstr_tol explicitly when user provided it or no cstr_specs is used.
-        // When cstr_specs is set without explicit cstr_tol, let Rust default it.
-        if self.cstr_tol.is_some() || self.cstr_specs.is_none() {
+        // Only set cstr_tol explicitly when user provided it.
+        // Otherwise let Rust infer the correct total length, including
+        // expanded constraints and function constraints.
+        if self.cstr_tol.is_some() {
             let cstr_tol = self.cstr_tol(n_fcstr);
             config = config.cstr_tol(cstr_tol);
         }


### PR DESCRIPTION
This pull request introduces support for specifying how function constraints are interpreted in the EGO optimizer by allowing users to provide constraint specifications (`CstrSpec`) alongside constraint functions. The changes include new APIs for passing these specs, internal validation, and logic to transform and handle constraints according to their specifications. Additionally, the pull request improves constraint tolerance handling and adds comprehensive tests for the new functionality.

**Constraint specification and transformation:**

* Added a new `subject_to_with_specs` method to `EgorFactory` and `EgorBuilder`, allowing users to define both constraint functions and their specifications (`CstrSpec`). Internal validation ensures the number of specifications matches the number of constraints. (`crates/ego/src/egor.rs`) [[1]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R203) [[2]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R219) [[3]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R237-R263) [[4]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R288-R296) [[5]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R310-R318)
* Updated the constraint transformation logic throughout the solver pipeline to apply affine transformations based on `CstrSpec`, ensuring all constraints are handled in a canonical form (`scale * raw + offset <= 0`). (`crates/ego/src/solver/solver_impl.rs`, `crates/ego/src/solver/trego.rs`, `crates/ego/src/solver/solver_computations.rs`, `crates/ego/src/types.rs`) [[1]](diffhunk://#diff-0d1f5cffeddecbcdc5f2908e09bde71afb47754e029812249989cc182d385139R577-R584) [[2]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758R417-R440) [[3]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758L431-R457) [[4]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758R742) [[5]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758R758) [[6]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758R915) [[7]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758R1100-R1130) [[8]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758L1096-R1150) [[9]](diffhunk://#diff-c9efa0156850437c91f2285b541f80c18811a57109e37e8eab16756e99d16758L1118-R1178) [[10]](diffhunk://#diff-10e4b103af87604b41f5a766c3c6039f6fe0f60016e8c8630a91df5ef5988cc4R109-R131) [[11]](diffhunk://#diff-10e4b103af87604b41f5a766c3c6039f6fe0f60016e8c8630a91df5ef5988cc4L118-R141) [[12]](diffhunk://#diff-c8da0f7290217b622a1b12c552a8e1a087aa0d37407a206baf5927528ff2d1bfL136-R154)

**Validation and error handling:**

* Added validation to ensure that the number of constraint specifications matches the number of constraint functions, with clear error reporting for mismatches. (`crates/ego/src/egor.rs`) [[1]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R237-R263) [[2]](diffhunk://#diff-c2cd1988d78fa699e6f0a8255ca4ebef6ac0b79bb5b68a2590f53e45b2245697R1175-R1228)
* Improved error handling for constraint tolerance arrays, ensuring their length is appropriate for the number of internal constraints and padding if necessary. (`crates/ego/src/solver/egor_config.rs`, `crates/ego/src/solver/egor_solver.rs`) [[1]](diffhunk://#diff-babc32a3f5aeedb0499e23ee12db7a4e2fd4e008dd22743d29cc5f21e84cf067L766-R769) [[2]](diffhunk://#diff-730897193f799a5680290a69c7da905c699da4697e97b8a4acdacec939cb7b40L287-R306)

**Testing and documentation:**

* Added new tests to verify correct behavior when using constraint specifications, including cases for mismatched lengths. (`crates/ego/src/egor.rs`)
* Updated documentation and examples to reflect the new `terms` method for `CstrSpec` and its usage. (`crates/ego/src/types.rs`) [[1]](diffhunk://#diff-c8da0f7290217b622a1b12c552a8e1a087aa0d37407a206baf5927528ff2d1bfL101-R115) [[2]](diffhunk://#diff-c8da0f7290217b622a1b12c552a8e1a087aa0d37407a206baf5927528ff2d1bfL136-R154)