### PR TITLE
Python API accepts simple types int/dict for enum/struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you find this project useful for your research, you may cite it as follows:
 @article{
   Lafage2022, 
   author = {Rémi Lafage}, 
-  title = {egobox, a Rust toolbox for efficient global optimization}, 
+  title = {EGObox, a Rust toolbox for efficient global optimization}, 
   journal = {Journal of Open Source Software} 
   year = {2022}, 
   doi = {10.21105/joss.04737}, 

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -965,8 +965,6 @@ where
                 log::debug!("activity: {activity:?}");
                 let actives = activity;
 
-                info!("Train surrogates with {} points...", xt.nrows());
-
                 let do_clustering = ((init && i == 0) || recluster).into();
                 let optimize_theta = ((iter as usize * self.config.qei_config.batch + i)
                     .is_multiple_of(self.config.qei_config.optmod)

--- a/python/egobox/tests/test_api.py
+++ b/python/egobox/tests/test_api.py
@@ -98,6 +98,34 @@ class TestApiImports(unittest.TestCase):
         self.assertEqual(optim.status.info.fname, "fobj")
         self.assertEqual(optim.status.info.num, 7)
 
+    def test_sampling_accepts_int_method(self):
+        import egobox as egx
+
+        doe = egx.sampling(1, [[0.0, 1.0]], 4, seed=1)
+        self.assertEqual(doe.shape, (4, 1))
+
+    def test_xspec_and_sparse_method_accept_int(self):
+        import egobox as egx
+
+        xspec = egx.XSpec(1, [0.0, 1.0])
+        self.assertEqual(xspec.xtype, egx.XType.FLOAT)
+
+        sgp = egx.SparseGpMix(nz=3, method=2)
+        self.assertIsNotNone(sgp)
+
+    def test_cstr_spec_accepts_dict_form(self):
+        import egobox as egx
+
+        def fobj(x: np.ndarray) -> np.ndarray:
+            x = np.atleast_2d(x)
+            obj = np.sum(x**2, axis=1).reshape(-1, 1)
+            cst = x[:, 0].reshape(-1, 1)
+            return np.hstack((obj, cst))
+
+        egor = egx.Egor([[0.0, 1.0]], n_cstr=1, cstr_specs=[{"leq": 0.8}], infill_strategy=1)
+        optim = egor.minimize(fobj, max_iters=1, seed=42)
+        self.assertEqual(optim.status.total_iters, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/egobox/tests/test_api.py
+++ b/python/egobox/tests/test_api.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 
 
 class TestApiImports(unittest.TestCase):
@@ -69,6 +70,33 @@ class TestApiImports(unittest.TestCase):
         for name, symbol in imported_symbols.items():
             self.assertTrue(hasattr(egx, name), f"egobox is missing '{name}'")
             self.assertIs(symbol, getattr(egx, name))
+
+    def test_egor_accepts_int_and_dict_arguments(self):
+        import egobox as egx
+
+        egor = egx.Egor(
+            [[0.0, 1.0]],
+            gp_config={"n_clusters": 0, "recombination": 1},
+            qei_config={"batch": 2, "strategy": 2, "optmod": 1},
+            infill_strategy=4,
+            cstr_strategy=1,
+            infill_optimizer=2,
+            failsafe_strategy=3,
+            trego={"alpha": 0.8},
+        )
+        self.assertIsNotNone(egor)
+
+    def test_minimize_accepts_run_info_dict(self):
+        import egobox as egx
+
+        def fobj(x: np.ndarray) -> np.ndarray:
+            x = np.atleast_2d(x)
+            return np.sum(x**2, axis=1).reshape(-1, 1)
+
+        egor = egx.Egor([[0.0, 1.0]], infill_strategy=1)
+        optim = egor.minimize(fobj, max_iters=1, seed=42, run_info={"fname": "fobj", "num": 7})
+        self.assertEqual(optim.status.info.fname, "fobj")
+        self.assertEqual(optim.status.info.num, 7)
 
 
 if __name__ == "__main__":

--- a/python/egobox/tests/test_api.py
+++ b/python/egobox/tests/test_api.py
@@ -94,7 +94,9 @@ class TestApiImports(unittest.TestCase):
             return np.sum(x**2, axis=1).reshape(-1, 1)
 
         egor = egx.Egor([[0.0, 1.0]], infill_strategy=1)
-        optim = egor.minimize(fobj, max_iters=1, seed=42, run_info={"fname": "fobj", "num": 7})
+        optim = egor.minimize(
+            fobj, max_iters=1, seed=42, run_info={"fname": "fobj", "num": 7}
+        )
         self.assertEqual(optim.status.info.fname, "fobj")
         self.assertEqual(optim.status.info.num, 7)
 
@@ -122,7 +124,9 @@ class TestApiImports(unittest.TestCase):
             cst = x[:, 0].reshape(-1, 1)
             return np.hstack((obj, cst))
 
-        egor = egx.Egor([[0.0, 1.0]], n_cstr=1, cstr_specs=[{"leq": 0.8}], infill_strategy=1)
+        egor = egx.Egor(
+            [[0.0, 1.0]], n_cstr=1, cstr_specs=[{"leq": 0.8}], infill_strategy=1
+        )
         optim = egor.minimize(fobj, max_iters=1, seed=42)
         self.assertEqual(optim.status.total_iters, 1)
 

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -181,24 +181,18 @@ fn parse_run_info(py: Python, value: Py<PyAny>) -> PyResult<RunInfo> {
 ///
 ///     seed (int >= 0 or None):
 ///         Deprecated: use seed argument in minimize() or suggest() instead.
-///         Random generator seed to allow computation reproducibility.
 ///
 ///     outdir (String or None):
 ///         Deprecated: use outdir argument in minimize() instead.
-///         Directory to write optimization history and used as search path for warm start doe.
 ///
 ///     warm_start (bool):
 ///         Deprecated: use warm_start argument in minimize() instead.
-///         Start by loading initial doe from <outdir> directory.
 ///
 ///     hot_start (bool, int >= 0 or None):
 ///         Deprecated: use hot_start argument in minimize() instead.
-///         When True, hot_start behaves like hot_start=0 with no iteration extension.
-///         When hot_start>=0 saves optimizer state at each iteration and starts from a previous checkpoint.
 ///
 ///     verbose (int, Verbose enum, or None):
 ///         Deprecated: use verbose argument in minimize() instead.
-///         Logging verbosity level for the optimizer.
 ///
 /// # Returns
 ///
@@ -424,14 +418,12 @@ impl Egor {
     ///         Start by loading initial doe from <outdir> directory
     ///
     ///     hot_start (bool, int >= 0 or None):
-    ///         When True, hot_start behaves like hot_start=0 with no iteration extension.
     ///         When hot_start>=0 saves optimizer state at each iteration and starts from a previous checkpoint
-    ///         if any for the given hot_start number of iterations beyond the max_iters nb of iterations.
+    ///         for the given hot_start number of iterations beyond the max_iters nb of iterations.
     ///         In an unstable environment were there can be crashes it allows to restart the optimization
     ///         from the last iteration till stopping criterion is reached. Just use hot_start=0 in this case.
-    ///         When specifying an extended nb of iterations (hot_start > 0) it can allow to continue till max_iters +
-    ///         hot_start nb of iters is reached (provided the stopping criterion is max_iters)
-    ///         Checkpoint information is stored in .checkpoint/egor.arg binary file.
+    ///         When True, hot_start behaves like hot_start=0 with no iteration extension.
+    ///         Checkpoint information is stored in .checkpoint or under outdir if outdir is specified.
     ///
     ///     seed (int >= 0):
     ///         Random generator seed to allow computation reproducibility.

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -30,6 +30,57 @@ use pyo3::types::PyBool;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use std::cmp::Ordering;
 
+fn parse_trego_config(py: Python, value: Py<PyAny>) -> PyResult<TregoConfigSpec> {
+    if let Ok(spec) = value.extract(py) {
+        return Ok(spec);
+    }
+
+    let dict = value.bind(py).cast::<pyo3::types::PyDict>()?;
+    let mut cfg = TregoConfig::default();
+
+    for key_any in dict.keys().iter() {
+        let key = key_any.extract::<String>()?;
+        match key.as_str() {
+            "n_gl_steps" => cfg.n_gl_steps = dict.get_item("n_gl_steps")?.unwrap().extract()?,
+            "d" => cfg.d = dict.get_item("d")?.unwrap().extract()?,
+            "alpha" => cfg.alpha = dict.get_item("alpha")?.unwrap().extract()?,
+            "beta" => cfg.beta = dict.get_item("beta")?.unwrap().extract()?,
+            "sigma0" => cfg.sigma0 = dict.get_item("sigma0")?.unwrap().extract()?,
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown trego key '{key}'"
+                )))
+            }
+        }
+    }
+
+    Ok(TregoConfigSpec::Custom(cfg))
+}
+
+fn parse_run_info(py: Python, value: Py<PyAny>) -> PyResult<RunInfo> {
+    if let Ok(info) = value.extract(py) {
+        return Ok(info);
+    }
+
+    let dict = value.bind(py).cast::<pyo3::types::PyDict>()?;
+    let mut info = RunInfo::new("fobj".to_string(), 1);
+
+    for key_any in dict.keys().iter() {
+        let key = key_any.extract::<String>()?;
+        match key.as_str() {
+            "fname" => info.fname = dict.get_item("fname")?.unwrap().extract()?,
+            "num" => info.num = dict.get_item("num")?.unwrap().extract()?,
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown run_info key '{key}'"
+                )))
+            }
+        }
+    }
+
+    Ok(info)
+}
+
 /// Optimizer constructor
 ///
 /// # Parameters
@@ -284,8 +335,7 @@ impl Egor {
         // Parse trego configuration: boolean or custom configuration
         let trego = match trego {
             Some(trego_py) => {
-                let trego_typ: TregoConfigSpec =
-                    trego_py.extract(py).expect("Bad TREGO configuration");
+                let trego_typ = parse_trego_config(py, trego_py).expect("Bad TREGO configuration");
                 match trego_typ {
                     TregoConfigSpec::Activated(active) => {
                         if active {
@@ -511,8 +561,7 @@ impl Egor {
             .expect("Egor configured");
 
         let py_run_info = if let Some(ri) = run_info {
-            let ri: RunInfo = ri.extract(py).unwrap();
-            ri
+            parse_run_info(py, ri)?
         } else {
             RunInfo {
                 fname: "objective_function".to_string(),

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -46,11 +46,7 @@ fn parse_trego_config(py: Python, value: Py<PyAny>) -> PyResult<TregoConfigSpec>
             "alpha" => cfg.alpha = dict.get_item("alpha")?.unwrap().extract()?,
             "beta" => cfg.beta = dict.get_item("beta")?.unwrap().extract()?,
             "sigma0" => cfg.sigma0 = dict.get_item("sigma0")?.unwrap().extract()?,
-            _ => {
-                return Err(PyValueError::new_err(format!(
-                    "unknown trego key '{key}'"
-                )))
-            }
+            _ => return Err(PyValueError::new_err(format!("unknown trego key '{key}'"))),
         }
     }
 
@@ -73,7 +69,7 @@ fn parse_run_info(py: Python, value: Py<PyAny>) -> PyResult<RunInfo> {
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "unknown run_info key '{key}'"
-                )))
+                )));
             }
         }
     }

--- a/python/src/gp_config.rs
+++ b/python/src/gp_config.rs
@@ -102,7 +102,11 @@ impl<'a, 'py> FromPyObject<'a, 'py> for GpConfig {
                 }
                 "n_start" => cfg.n_start = dict.get_item("n_start")?.unwrap().extract()?,
                 "max_eval" => cfg.max_eval = dict.get_item("max_eval")?.unwrap().extract()?,
-                _ => return Err(PyValueError::new_err(format!("unknown gp_config key '{key}'"))),
+                _ => {
+                    return Err(PyValueError::new_err(format!(
+                        "unknown gp_config key '{key}'"
+                    )));
+                }
             }
         }
 

--- a/python/src/gp_config.rs
+++ b/python/src/gp_config.rs
@@ -1,10 +1,12 @@
 use crate::types::*;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict};
 use pyo3_stub_gen::derive::gen_stub_pyclass;
 
 /// GP configuration used by `Egor` and `GpMix`
 #[gen_stub_pyclass]
-#[pyclass(from_py_object)]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub(crate) struct GpConfig {
     /// (RegressionSpec flags, an int in [1, 7])
@@ -71,6 +73,41 @@ pub(crate) struct GpConfig {
     ///   Max number of likelihood evaluations during GP hyperparameters optimization
     #[pyo3(get, set)]
     pub max_eval: usize,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for GpConfig {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(cfg) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(cfg.clone());
+        }
+
+        let dict = obj.cast::<PyDict>()?;
+        let mut cfg = GpConfig::default();
+
+        for key_any in dict.keys().iter() {
+            let key = key_any.extract::<String>()?;
+            match key.as_str() {
+                "regr_spec" => cfg.regr_spec = dict.get_item("regr_spec")?.unwrap().extract()?,
+                "corr_spec" => cfg.corr_spec = dict.get_item("corr_spec")?.unwrap().extract()?,
+                "kpls_dim" => cfg.kpls_dim = dict.get_item("kpls_dim")?.unwrap().extract()?,
+                "n_clusters" => cfg.n_clusters = dict.get_item("n_clusters")?.unwrap().extract()?,
+                "recombination" => {
+                    cfg.recombination = dict.get_item("recombination")?.unwrap().extract()?
+                }
+                "theta_init" => cfg.theta_init = dict.get_item("theta_init")?.unwrap().extract()?,
+                "theta_bounds" => {
+                    cfg.theta_bounds = dict.get_item("theta_bounds")?.unwrap().extract()?
+                }
+                "n_start" => cfg.n_start = dict.get_item("n_start")?.unwrap().extract()?,
+                "max_eval" => cfg.max_eval = dict.get_item("max_eval")?.unwrap().extract()?,
+                _ => return Err(PyValueError::new_err(format!("unknown gp_config key '{key}'"))),
+            }
+        }
+
+        Ok(cfg)
+    }
 }
 
 impl Default for GpConfig {

--- a/python/src/qei_config.rs
+++ b/python/src/qei_config.rs
@@ -1,5 +1,7 @@
 use crate::types::*;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict};
 use pyo3_stub_gen::derive::gen_stub_pyclass;
 
 /// Configuration for parallel (qEI) infill criterion evaluation.
@@ -27,7 +29,7 @@ use pyo3_stub_gen::derive::gen_stub_pyclass;
 ///     For example, with q_optmod=2, hyperparameters are optimized every 2 points.
 ///
 #[gen_stub_pyclass]
-#[pyclass(from_py_object)]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub(crate) struct QEiConfig {
     /// Number of points to evaluate in parallel
@@ -41,6 +43,35 @@ pub(crate) struct QEiConfig {
     /// Interval between hyperparameter optimizations
     #[pyo3(get, set)]
     pub optmod: usize,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for QEiConfig {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(cfg) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(cfg.clone());
+        }
+
+        let dict = obj.cast::<PyDict>()?;
+        let mut cfg = QEiConfig::default();
+
+        for key_any in dict.keys().iter() {
+            let key = key_any.extract::<String>()?;
+            match key.as_str() {
+                "batch" => cfg.batch = dict.get_item("batch")?.unwrap().extract()?,
+                "strategy" => cfg.strategy = dict.get_item("strategy")?.unwrap().extract()?,
+                "optmod" => cfg.optmod = dict.get_item("optmod")?.unwrap().extract()?,
+                _ => {
+                    return Err(PyValueError::new_err(format!(
+                        "unknown qei_config key '{key}'"
+                    )))
+                }
+            }
+        }
+
+        Ok(cfg)
+    }
 }
 
 impl Default for QEiConfig {

--- a/python/src/qei_config.rs
+++ b/python/src/qei_config.rs
@@ -65,7 +65,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for QEiConfig {
                 _ => {
                     return Err(PyValueError::new_err(format!(
                         "unknown qei_config key '{key}'"
-                    )))
+                    )));
                 }
             }
         }

--- a/python/src/sampling.rs
+++ b/python/src/sampling.rs
@@ -2,11 +2,12 @@ use crate::domain;
 use egobox_doe::{LhsKind, SamplingMethod};
 use egobox_moe::MixintContext;
 use numpy::{IntoPyArray, PyArray2};
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass_enum, gen_stub_pyfunction};
 
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Sampling {
     Lhs = 1,
@@ -16,6 +17,31 @@ pub enum Sampling {
     LhsCentered = 5,
     LhsMaximin = 6,
     LhsCenteredMaximin = 7,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for Sampling {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Lhs),
+            Ok(2) => Ok(Self::FullFactorial),
+            Ok(3) => Ok(Self::Random),
+            Ok(4) => Ok(Self::LhsClassic),
+            Ok(5) => Ok(Self::LhsCentered),
+            Ok(6) => Ok(Self::LhsMaximin),
+            Ok(7) => Ok(Self::LhsCenteredMaximin),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "sampling method integer value must be in [1, 7], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "method must be a Sampling enum or an integer in [1, 7]",
+            )),
+        }
+    }
 }
 
 /// Samples generation using given method

--- a/python/src/trego_config.rs
+++ b/python/src/trego_config.rs
@@ -77,9 +77,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for TregoConfig {
                 "alpha" => cfg.alpha = dict.get_item("alpha")?.unwrap().extract()?,
                 "beta" => cfg.beta = dict.get_item("beta")?.unwrap().extract()?,
                 "sigma0" => cfg.sigma0 = dict.get_item("sigma0")?.unwrap().extract()?,
-                _ => {
-                    return Err(PyValueError::new_err(format!("unknown trego key '{key}'")))
-                }
+                _ => return Err(PyValueError::new_err(format!("unknown trego key '{key}'"))),
             }
         }
 

--- a/python/src/trego_config.rs
+++ b/python/src/trego_config.rs
@@ -1,4 +1,6 @@
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict};
 use pyo3_stub_gen::derive::gen_stub_pyclass;
 
 /// TREGO configuration specification which can be either
@@ -31,7 +33,7 @@ pub enum TregoConfigSpec {
 /// sigma0 : float
 ///     Initial trust region radius.
 #[gen_stub_pyclass]
-#[pyclass(from_py_object)]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub(crate) struct TregoConfig {
     /// Number of global optimization steps
@@ -54,6 +56,35 @@ pub(crate) struct TregoConfig {
     /// Initial trust region radius
     #[pyo3(get, set)]
     pub sigma0: f64,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for TregoConfig {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(cfg) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(cfg.clone());
+        }
+
+        let dict = obj.cast::<PyDict>()?;
+        let mut cfg = TregoConfig::default();
+
+        for key_any in dict.keys().iter() {
+            let key = key_any.extract::<String>()?;
+            match key.as_str() {
+                "n_gl_steps" => cfg.n_gl_steps = dict.get_item("n_gl_steps")?.unwrap().extract()?,
+                "d" => cfg.d = dict.get_item("d")?.unwrap().extract()?,
+                "alpha" => cfg.alpha = dict.get_item("alpha")?.unwrap().extract()?,
+                "beta" => cfg.beta = dict.get_item("beta")?.unwrap().extract()?,
+                "sigma0" => cfg.sigma0 = dict.get_item("sigma0")?.unwrap().extract()?,
+                _ => {
+                    return Err(PyValueError::new_err(format!("unknown trego key '{key}'")))
+                }
+            }
+        }
+
+        Ok(cfg)
+    }
 }
 
 impl Default for TregoConfig {

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -266,7 +266,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for FailsafeStrategy {
 
 /// Verbose specifies the level of verbosity for logging.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub(crate) enum Verbose {
     Error = 0,
@@ -274,6 +274,29 @@ pub(crate) enum Verbose {
     Info = 2,
     Debug = 3,
     Trace = 4,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for Verbose {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, PyErr> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(0) => Ok(Self::Error),
+            Ok(1) => Ok(Self::Warning),
+            Ok(2) => Ok(Self::Info),
+            Ok(3) => Ok(Self::Debug),
+            Ok(4) => Ok(Self::Trace),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "verbose integer value must be in [0, 4], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "verbose must be a Verbose enum or an integer in [0, 4]",
+            )),
+        }
+    }
 }
 
 impl From<Verbose> for log::LevelFilter {
@@ -290,13 +313,35 @@ impl From<Verbose> for log::LevelFilter {
 
 /// XType specifies the type of the input variables.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum XType {
     Float = 1,
     Int = 2,
     Ord = 3,
     Enum = 4,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for XType {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Float),
+            Ok(2) => Ok(Self::Int),
+            Ok(3) => Ok(Self::Ord),
+            Ok(4) => Ok(Self::Enum),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "xtype integer value must be in [1, 4], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "xtype must be an XType enum or an integer in [1, 4]",
+            )),
+        }
+    }
 }
 
 /// XSpec specifies the type and limits of the input variables (aka design space).
@@ -328,7 +373,7 @@ impl XSpec {
 
 /// SparseMethod specifies the method to use for sparse Gaussian process regression.
 /// See "Sparse Gaussian Process Regression for Big Data" by V. Vanhatalo, J. Riihimäki, J. Hartikainen, and A. Vehtari (2010)
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[gen_stub_pyclass_enum]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum SparseMethod {
@@ -336,6 +381,26 @@ pub(crate) enum SparseMethod {
     Fitc = 1,
     /// VFE (Variational Free Energy) method, which uses a variational approach to approximate the posterior, resulting in a more accurate but slower model
     Vfe = 2,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for SparseMethod {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Fitc),
+            Ok(2) => Ok(Self::Vfe),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "sparse method integer value must be in [1, 2], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "method must be a SparseMethod enum or an integer in [1, 2]",
+            )),
+        }
+    }
 }
 
 /// CstrSpec specifies how a constraint should be interpreted by the optimizer.
@@ -361,10 +426,45 @@ pub(crate) enum SparseMethod {
 /// spec4 = egx.CstrSpec.btw(1.0, 3.0)
 /// ```
 #[gen_stub_pyclass]
-#[pyclass(from_py_object)]
+#[pyclass(skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub(crate) struct CstrSpec {
     pub(crate) inner: egobox_ego::CstrSpec,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for CstrSpec {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(spec) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(spec.clone());
+        }
+
+        let dict = obj.cast::<pyo3::types::PyDict>()?;
+        if dict.len() != 1 {
+            return Err(PyValueError::new_err(
+                "CstrSpec dict form must contain exactly one key among: leq, geq, eq, btw",
+            ));
+        }
+
+        if let Some(value) = dict.get_item("leq")? {
+            return Ok(CstrSpec::leq(value.extract()?));
+        }
+        if let Some(value) = dict.get_item("geq")? {
+            return Ok(CstrSpec::geq(value.extract()?));
+        }
+        if let Some(value) = dict.get_item("eq")? {
+            return Ok(CstrSpec::eq(value.extract()?));
+        }
+        if let Some(value) = dict.get_item("btw")? {
+            let (lower, upper): (f64, f64) = value.extract()?;
+            return Ok(CstrSpec::btw(lower, upper));
+        }
+
+        Err(PyValueError::new_err(
+            "Unknown CstrSpec dict key. Expected one of: leq, geq, eq, btw",
+        ))
+    }
 }
 
 #[gen_stub_pymethods]

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -448,7 +448,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for RunInfo {
                 _ => {
                     return Err(PyValueError::new_err(format!(
                         "unknown run_info key '{key}'"
-                    )))
+                    )));
                 }
             }
         }

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -1,9 +1,10 @@
 use numpy::{PyArray1, PyArray2};
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
 
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Recombination {
     /// prediction is taken from the expert with highest responsability
@@ -13,6 +14,26 @@ pub enum Recombination {
     /// an optional heaviside factor might be used control steepness of the change between
     /// experts regions.
     Smooth = 1,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for Recombination {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(value.clone());
+        }
+        match obj.extract::<u8>() {
+            Ok(0) => Ok(Self::Hard),
+            Ok(1) => Ok(Self::Smooth),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "recombination integer value must be in [0, 1], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "recombination must be a Recombination enum or an integer in [0, 1]",
+            )),
+        }
+    }
 }
 
 /// RegressionSpec is a bitfield that specifies which regression terms to include in the model.
@@ -59,7 +80,7 @@ impl CorrelationSpec {
 
 /// InfillStrategy specifies the acquisition function to use for infill optimization.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum InfillStrategy {
     /// Expected Improvement
@@ -76,9 +97,31 @@ pub(crate) enum InfillStrategy {
     LogEi = 4,
 }
 
+impl<'a, 'py> FromPyObject<'a, 'py> for InfillStrategy {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Ei),
+            Ok(2) => Ok(Self::Wb2),
+            Ok(3) => Ok(Self::Wb2s),
+            Ok(4) => Ok(Self::LogEi),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "infill_strategy integer value must be in [1, 4], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "infill_strategy must be an InfillStrategy enum or an integer in [1, 4]",
+            )),
+        }
+    }
+}
+
 /// ConstraintStrategy specifies the strategy to use for handling constraints in infill optimization.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum ConstraintStrategy {
     /// Mean of the GP is used to evaluate the constraint, which is equivalent to ignoring the uncertainty on the constraint
@@ -87,11 +130,31 @@ pub(crate) enum ConstraintStrategy {
     Utb = 2,
 }
 
+impl<'a, 'py> FromPyObject<'a, 'py> for ConstraintStrategy {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Mc),
+            Ok(2) => Ok(Self::Utb),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "cstr_strategy integer value must be in [1, 2], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "cstr_strategy must be a ConstraintStrategy enum or an integer in [1, 2]",
+            )),
+        }
+    }
+}
+
 /// QEiStrategy specifies the strategy to use for handling constraints in infill optimization.
 /// see QEI is the multi-point extension of EI, see Chevalier and Ginsbourger (2013)
 /// "Fast Computation of the Multi-Points Expected Improvement with Applications in Batch Selection"
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum QEiStrategy {
     /// Kriging Believer, the next point is added to the GP with its predicted mean value,
@@ -111,9 +174,31 @@ pub(crate) enum QEiStrategy {
     Clmin = 4,
 }
 
+impl<'a, 'py> FromPyObject<'a, 'py> for QEiStrategy {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Kb),
+            Ok(2) => Ok(Self::Kblb),
+            Ok(3) => Ok(Self::Kbub),
+            Ok(4) => Ok(Self::Clmin),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "qei strategy integer value must be in [1, 4], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "qei strategy must be a QEiStrategy enum or an integer in [1, 4]",
+            )),
+        }
+    }
+}
+
 /// InfillOptimizer specifies the optimization algorithm to use for infill optimization.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum InfillOptimizer {
     /// Gradient free optimization algorithm that uses a simplex of n+1 points for n-dimensional optimization
@@ -122,9 +207,29 @@ pub(crate) enum InfillOptimizer {
     Slsqp = 2,
 }
 
+impl<'a, 'py> FromPyObject<'a, 'py> for InfillOptimizer {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Cobyla),
+            Ok(2) => Ok(Self::Slsqp),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "infill_optimizer integer value must be in [1, 2], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "infill_optimizer must be an InfillOptimizer enum or an integer in [1, 2]",
+            )),
+        }
+    }
+}
+
 /// FailsafeStrategy specifies the strategy to use for handling failures during infill optimization.
 #[gen_stub_pyclass_enum]
-#[pyclass(from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub(crate) enum FailsafeStrategy {
     /// The point is ignored, the optimization continues but may fail to explore
@@ -136,6 +241,27 @@ pub(crate) enum FailsafeStrategy {
     /// The viability of the point is modeled with a surrogate, which allows the optimization
     /// to learn which regions of the search space are more likely to fail and avoid them in the future
     Viability = 3,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for FailsafeStrategy {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(*value);
+        }
+        match obj.extract::<u8>() {
+            Ok(1) => Ok(Self::Rejection),
+            Ok(2) => Ok(Self::Imputation),
+            Ok(3) => Ok(Self::Viability),
+            Ok(v) => Err(PyValueError::new_err(format!(
+                "failsafe_strategy integer value must be in [1, 3], got {v}"
+            ))),
+            Err(_) => Err(PyTypeError::new_err(
+                "failsafe_strategy must be a FailsafeStrategy enum or an integer in [1, 3]",
+            )),
+        }
+    }
 }
 
 /// Verbose specifies the level of verbosity for logging.
@@ -289,7 +415,7 @@ impl CstrSpec {
 /// This information is also returned in the RunStatus to allow the user to correlate the results
 /// with the function and run number.
 #[gen_stub_pyclass]
-#[pyclass(from_py_object)]
+#[pyclass(skip_from_py_object)]
 #[derive(Debug, Clone)]
 pub(crate) struct RunInfo {
     /// A name for the function being optimized, used for logging and saving results
@@ -298,6 +424,37 @@ pub(crate) struct RunInfo {
     /// A number for the run, used for logging and saving results
     #[pyo3(get, set)]
     pub(crate) num: usize,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for RunInfo {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(info) = obj.extract::<PyRef<'py, Self>>() {
+            return Ok(info.clone());
+        }
+
+        let dict = obj.cast::<pyo3::types::PyDict>()?;
+        let mut info = RunInfo {
+            fname: "fobj".to_string(),
+            num: 1,
+        };
+
+        for key_any in dict.keys().iter() {
+            let key = key_any.extract::<String>()?;
+            match key.as_str() {
+                "fname" => info.fname = dict.get_item("fname")?.unwrap().extract()?,
+                "num" => info.num = dict.get_item("num")?.unwrap().extract()?,
+                _ => {
+                    return Err(PyValueError::new_err(format!(
+                        "unknown run_info key '{key}'"
+                    )))
+                }
+            }
+        }
+
+        Ok(info)
+    }
 }
 
 #[gen_stub_pymethods]


### PR DESCRIPTION
It can be easier to integrate Egor in existing framework using simple types like int or dict instead of enum or struct.

Typically `pyoptsparse` requires algorithm options being pickable. At the moment pickle protocol is not supported by PyO3 so a workaround is to be able to use such simple (pickable) builtin types.