### PR TITLE
Add the configuration of objective-error handling

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -558,7 +558,7 @@ mod tests {
     use serial_test::serial;
     use std::time::Instant;
 
-    use crate::{CoegoStatus, DOE_FILE, DOE_INITIAL_FILE};
+    use crate::{CoegoStatus, DOE_FILE, DOE_INITIAL_FILE, OBJECTIVE_FUNCTION_ERROR};
     use egobox_moe::{CorrelationSpec, RegressionSpec};
 
     #[cfg(not(feature = "blas"))]
@@ -1632,7 +1632,7 @@ mod tests {
         assert_eq!(
             result.state.termination_status,
             TerminationStatus::Terminated(TerminationReason::SolverExit(
-                "Objective Function failure".to_string()
+                OBJECTIVE_FUNCTION_ERROR.to_string()
             ))
         );
     }

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -1541,7 +1541,7 @@ mod tests {
             .expect("Egor should be configured")
             .run()
             .expect("Egor should minimize branin_with_nans");
-        // The optimizer stalls with default NaNs rejection policy
+        // The optimizer stalls with the explicit NaNs rejection policy
         // Only some good doe points are kept, no further point is added
         // as the optimizer wants to peek in the bad region
         assert!(N_DOE + MAX_ITERS >= res.x_doe.nrows());
@@ -1586,6 +1586,23 @@ mod tests {
         assert!(res.state.surrogate.x_fail.is_some());
     }
 
+    #[test]
+    #[serial]
+    fn test_egor_stops_on_objective_failure_by_default() {
+        let objective = |_x: &ArrayView2<f64>| -> std::result::Result<Array2<f64>, String> {
+            Err("simulated objective failure".to_string())
+        };
+
+        let result = EgorBuilder::optimize(objective)
+            .configure(|cfg| cfg.max_iters(0).seed(42))
+            .min_within(&array![[0.0, 1.0]])
+            .expect("Egor should be configured")
+            .run();
+
+        let error = result.expect_err("objective failure should stop optimization");
+        assert!(error.to_string().contains("simulated objective failure"));
+    }
+
     // sphere function which save nb of calls in temporary file
     // then read it to fail every 5 calls, to test periodic fails
     #[test]
@@ -1628,7 +1645,12 @@ mod tests {
 
         let max_iters = 12usize;
         let res = EgorBuilder::optimize(f)
-            .configure(|cfg| cfg.doe(&init_doe).max_iters(max_iters).seed(42))
+            .configure(|cfg| {
+                cfg.doe(&init_doe)
+                    .max_iters(max_iters)
+                    .failsafe_strategy(FailsafeStrategy::Rejection)
+                    .seed(42)
+            })
             .min_within(&xlimits)
             .expect("Egor configured")
             .run()

--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -1588,19 +1588,53 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_egor_stops_on_objective_failure_by_default() {
-        let objective = |_x: &ArrayView2<f64>| -> std::result::Result<Array2<f64>, String> {
-            Err("simulated objective failure".to_string())
+    fn test_egor_handles_objective_error_with_failsafe_by_default() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let objective_calls = calls.clone();
+        let objective = move |x: &ArrayView2<f64>| -> std::result::Result<Array2<f64>, String> {
+            if objective_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0 {
+                Ok(Array2::zeros((x.nrows(), 1)))
+            } else {
+                Err("simulated objective failure".to_string())
+            }
         };
 
         let result = EgorBuilder::optimize(objective)
-            .configure(|cfg| cfg.max_iters(0).seed(42))
+            .configure(|cfg| cfg.max_iters(1).seed(42))
             .min_within(&array![[0.0, 1.0]])
             .expect("Egor should be configured")
             .run();
 
-        let error = result.expect_err("objective failure should stop optimization");
-        assert!(error.to_string().contains("simulated objective failure"));
+        let result = result.expect("objective failure should use the failsafe by default");
+        assert!(result.state.surrogate.x_fail.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn test_egor_stops_on_objective_error_when_configured() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let objective_calls = calls.clone();
+        let objective = move |x: &ArrayView2<f64>| -> std::result::Result<Array2<f64>, String> {
+            if objective_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0 {
+                Ok(Array2::zeros((x.nrows(), 1)))
+            } else {
+                Err("simulated objective failure".to_string())
+            }
+        };
+
+        let result = EgorBuilder::optimize(objective)
+            .configure(|cfg| cfg.max_iters(1).stop_on_error(true).seed(42))
+            .min_within(&array![[0.0, 1.0]])
+            .expect("Egor should be configured")
+            .run()
+            .expect("objective failure should terminate optimization normally");
+
+        assert_eq!(
+            result.state.termination_status,
+            TerminationStatus::Terminated(TerminationReason::SolverExit(
+                "Objective Function failure".to_string()
+            ))
+        );
     }
 
     // sphere function which save nb of calls in temporary file

--- a/crates/ego/src/errors.rs
+++ b/crates/ego/src/errors.rs
@@ -14,9 +14,9 @@ pub enum EgoError {
     /// When LikelihoodComputation computation fails
     #[error("GP error")]
     GpError(#[from] egobox_gp::GpError),
-    /// When a user function evaluation fails
-    #[error("User function error: {0}")]
-    UserFnError(String),
+    /// When the objective function fails and optimization is configured to stop
+    #[error("Objective function error: {0}")]
+    ObjectiveFunctionError(String),
     /// When an invalid value is encountered
     #[error("Value error: {0}")]
     InvalidValue(String),

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -396,7 +396,7 @@ impl Default for ValidEgorConfig {
             cstr_infill: false,
             cstr_strategy: ConstraintStrategy::MeanConstraint,
             feasibility_infill: FeasibleInfillStrategy::None,
-            failsafe_strategy: FailsafeStrategy::Rejection,
+            failsafe_strategy: FailsafeStrategy::StopOnFailure,
             runtime_flags: RuntimeFlags::default(),
             iteration_strategy: Box::new(StandardEgoStrategy),
             activity_strategy: Box::new(FullActivity),

--- a/crates/ego/src/solver/egor_config.rs
+++ b/crates/ego/src/solver/egor_config.rs
@@ -364,6 +364,8 @@ pub struct ValidEgorConfig {
     pub(crate) feasibility_infill: FeasibleInfillStrategy,
     /// Failure handling strategy
     pub(crate) failsafe_strategy: FailsafeStrategy,
+    /// Stop optimization when the objective function returns an error instead of applying the failsafe strategy
+    pub(crate) stop_on_error: bool,
     /// Runtime behavior flags (replaces environment variable checks)
     pub(crate) runtime_flags: RuntimeFlags,
     /// Strategy controlling iteration flow (Standard EGO vs TREGO)
@@ -396,7 +398,8 @@ impl Default for ValidEgorConfig {
             cstr_infill: false,
             cstr_strategy: ConstraintStrategy::MeanConstraint,
             feasibility_infill: FeasibleInfillStrategy::None,
-            failsafe_strategy: FailsafeStrategy::StopOnFailure,
+            failsafe_strategy: FailsafeStrategy::Rejection,
+            stop_on_error: false,
             runtime_flags: RuntimeFlags::default(),
             iteration_strategy: Box::new(StandardEgoStrategy),
             activity_strategy: Box::new(FullActivity),
@@ -710,6 +713,14 @@ impl EgorConfig {
     /// Sets the objective evaluation failure handling strategy
     pub fn failsafe_strategy(mut self, failsafe_strategy: FailsafeStrategy) -> Self {
         self.0.failsafe_strategy = failsafe_strategy;
+        self
+    }
+
+    /// Sets whether an objective function error terminates optimization.
+    ///
+    /// When false, objective function errors are handled according to [`FailsafeStrategy`].
+    pub fn stop_on_error(mut self, stop_on_error: bool) -> Self {
+        self.0.stop_on_error = stop_on_error;
         self
     }
 

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -142,6 +142,8 @@ pub const DOE_FILE: &str = "egor_doe.npy";
 
 /// Default tolerance value for constraints to be satisfied (ie cstr < tol)
 pub const DEFAULT_CSTR_TOL: f64 = 1e-4;
+/// Termination reason when the objective function returns an error.
+pub const OBJECTIVE_FUNCTION_ERROR: &str = "Objective function error";
 
 /// Implementation of `argmin::core::Solver` for Egor optimizer.
 /// Therefore this structure can be used with `argmin::core::Executor` and benefit
@@ -491,7 +493,7 @@ where
             )),
             Err(EgoError::ObjectiveFunctionError(_)) => Ok((
                 state.terminate_with(TerminationReason::SolverExit(
-                    "Objective Function failure".to_string(),
+                    OBJECTIVE_FUNCTION_ERROR.to_string(),
                 )),
                 None,
             )),
@@ -528,7 +530,7 @@ where
         ) {
             Ok(state) => state,
             Err(crate::EgoError::ObjectiveFunctionError(_)) => fallback_state.terminate_with(
-                TerminationReason::SolverExit("Objective Function failure".to_string()),
+                TerminationReason::SolverExit(OBJECTIVE_FUNCTION_ERROR.to_string()),
             ),
             Err(err) => return Err(err.into()),
         };

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -489,6 +489,12 @@ where
                 state.terminate_with(TerminationReason::SolverConverged),
                 None,
             )),
+            Err(EgoError::ObjectiveFunctionError(_)) => Ok((
+                state.terminate_with(TerminationReason::SolverExit(
+                    "Objective Function failure".to_string(),
+                )),
+                None,
+            )),
             Err(err) => Err(err.into()),
         }
     }
@@ -511,14 +517,21 @@ where
         let models = self.refresh_surrogates(&state);
         let mut local_state = state;
         let infill_data = self.refresh_infill_data(problem, &mut local_state, &models);
-        let new_state = self.trego_step(
+        let fallback_state = local_state.clone();
+        let new_state = match self.trego_step(
             problem,
             local_state,
             models,
             &infill_data,
             max_dist,
             min_acceptance_distance,
-        )?;
+        ) {
+            Ok(state) => state,
+            Err(crate::EgoError::ObjectiveFunctionError(_)) => fallback_state.terminate_with(
+                TerminationReason::SolverExit("Objective Function failure".to_string()),
+            ),
+            Err(err) => return Err(err.into()),
+        };
         Ok((new_state, None))
     }
 }

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -214,7 +214,7 @@ where
             if doe.ncols() == self.xlimits.nrows() {
                 // only x are specified
                 info!("Compute initial DOE on specified {} points", doe.nrows());
-                (self.eval_obj(problem, doe), doe.to_owned())
+                (self.eval_obj(problem, doe)?, doe.to_owned())
             } else {
                 // split doe in x and y
                 info!("Use specified DOE {} samples", doe.nrows());
@@ -232,7 +232,7 @@ where
             info!("Compute initial LHS with {n_doe} points");
             let sampling = Lhs::new(&self.xlimits).with_rng(rng.clone());
             let x = sampling.sample(n_doe);
-            (self.eval_obj(problem, &x), x)
+            (self.eval_obj(problem, &x)?, x)
         };
         // Apply constraint transformation if cstr_specs are set
         let y_data = if let Some(ref specs) = self.config.cstr_specs {
@@ -518,7 +518,7 @@ where
             &infill_data,
             max_dist,
             min_acceptance_distance,
-        );
+        )?;
         Ok((new_state, None))
     }
 }

--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -610,8 +610,8 @@ where
             Ok(y) => Ok(y),
             Err(err) => {
                 warn!("Objective function evaluation failed at x = {x:?} with error: {err}");
-                if self.config.failsafe_strategy == FailsafeStrategy::StopOnFailure {
-                    Err(crate::EgoError::ArgminError(err))
+                if self.config.stop_on_error {
+                    Err(crate::EgoError::ObjectiveFunctionError(err.to_string()))
                 } else {
                     Ok(Array::from_shape_vec(
                         (x.nrows(), 1 + self.config.n_cstr),

--- a/crates/ego/src/solver/solver_computations.rs
+++ b/crates/ego/src/solver/solver_computations.rs
@@ -597,7 +597,7 @@ where
         &self,
         pb: &mut Problem<O>,
         x: &Array2<f64>,
-    ) -> Array2<f64> {
+    ) -> Result<Array2<f64>> {
         let x = if self.config.discrete() {
             // We have to cast x to folded space as EgorSolver
             // works internally in the continuous space while
@@ -606,15 +606,21 @@ where
         } else {
             x.to_owned()
         };
-        pb.problem("cost_count", |problem| problem.cost(&x))
-            .unwrap_or_else(|err| {
+        match pb.problem("cost_count", |problem| problem.cost(&x)) {
+            Ok(y) => Ok(y),
+            Err(err) => {
                 warn!("Objective function evaluation failed at x = {x:?} with error: {err}");
-                Array::from_shape_vec(
-                    (x.nrows(), 1 + self.config.n_cstr),
-                    vec![f64::NAN; x.nrows() * (1 + self.config.n_cstr)],
-                )
-                .unwrap()
-            })
+                if self.config.failsafe_strategy == FailsafeStrategy::StopOnFailure {
+                    Err(crate::EgoError::ArgminError(err))
+                } else {
+                    Ok(Array::from_shape_vec(
+                        (x.nrows(), 1 + self.config.n_cstr),
+                        vec![f64::NAN; x.nrows() * (1 + self.config.n_cstr)],
+                    )
+                    .unwrap())
+                }
+            }
+        }
     }
 
     /// Evaluate the constraints given as function at given x points

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -1057,9 +1057,7 @@ where
                                 y_pen_imputed,
                             );
                         }
-                        FailsafeStrategy::StopOnFailure
-                        | FailsafeStrategy::Rejection
-                        | FailsafeStrategy::Viability => (),
+                        FailsafeStrategy::Rejection | FailsafeStrategy::Viability => (),
                     }
                 };
 

--- a/crates/ego/src/solver/solver_impl.rs
+++ b/crates/ego/src/solver/solver_impl.rs
@@ -827,7 +827,7 @@ where
             }
         };
 
-        let y_actual = self.eval_obj(problem, &x_dat);
+        let y_actual = self.eval_obj(problem, &x_dat)?;
         // Apply constraint transformation if cstr_specs are set
         let y_actual = if let Some(ref specs) = self.config.cstr_specs {
             crate::types::transform_constraints(&y_actual, specs)
@@ -1057,7 +1057,9 @@ where
                                 y_pen_imputed,
                             );
                         }
-                        FailsafeStrategy::Rejection | FailsafeStrategy::Viability => (),
+                        FailsafeStrategy::StopOnFailure
+                        | FailsafeStrategy::Rejection
+                        | FailsafeStrategy::Viability => (),
                     }
                 };
 

--- a/crates/ego/src/solver/trego.rs
+++ b/crates/ego/src/solver/trego.rs
@@ -91,7 +91,7 @@ where
         infill_data: &InfillObjData<f64>,
         max_dist: f64,
         min_acceptance_distance: f64,
-    ) -> EgorState<f64> {
+    ) -> crate::errors::Result<EgorState<f64>> {
         let mut new_state = state.clone();
         let (mut x_data, mut y_data, mut c_data) = new_state.take_data().expect("DOE data");
 
@@ -190,7 +190,7 @@ where
             > min_acceptance_distance
             && is_update_ok(&x_data, &x_new.row(0))
         {
-            let y_new = self.eval_obj(problem, &x_new);
+            let y_new = self.eval_obj(problem, &x_new)?;
             // Apply constraint transformation if cstr_specs are set
             let y_new = if let Some(ref specs) = self.config.cstr_specs {
                 crate::types::transform_constraints(&y_new, specs)
@@ -263,7 +263,7 @@ where
         new_state = new_state.data((x_data, y_data, c_data)).rng(rng);
         new_state.surrogate.prev_best_index = new_state.surrogate.best_index;
         new_state.surrogate.best_index = Some(new_best_index);
-        new_state
+        Ok(new_state)
     }
 }
 

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -104,8 +104,10 @@ impl FeasibleInfillStrategy {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum FailsafeStrategy {
-    /// Failure point x is ignored
+    /// Stop optimization when the objective function evaluation fails
     #[default]
+    StopOnFailure,
+    /// Failure point x is ignored
     Rejection,
     /// Use objective surrogate prediction: y <- prediction(x) + variance(x)
     Imputation,

--- a/crates/ego/src/types.rs
+++ b/crates/ego/src/types.rs
@@ -100,14 +100,12 @@ impl FeasibleInfillStrategy {
     }
 }
 
-/// Strategy to handle objective computation failure at a given x point
+/// Strategy to handle objective computation failures represented by invalid output values.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub enum FailsafeStrategy {
-    /// Stop optimization when the objective function evaluation fails
-    #[default]
-    StopOnFailure,
     /// Failure point x is ignored
+    #[default]
     Rejection,
     /// Use objective surrogate prediction: y <- prediction(x) + variance(x)
     Imputation,
@@ -359,7 +357,7 @@ impl ObjFnResponse for Array2<f64> {
 
 impl<E: std::fmt::Display> ObjFnResponse for std::result::Result<Array2<f64>, E> {
     fn into_obj_result(self) -> Result<Array2<f64>> {
-        self.map_err(|e| EgoError::UserFnError(e.to_string()))
+        self.map_err(|e| EgoError::ObjectiveFunctionError(e.to_string()))
     }
 }
 
@@ -370,7 +368,8 @@ impl<E: std::fmt::Display> ObjFnResponse for std::result::Result<Array2<f64>, E>
 ///
 /// The function can return either `Array2<f64>` directly (infallible evaluation)
 /// or `Result<Array2<f64>, E>` (fallible evaluation) where `E` implements `Display`.
-/// On error, the optimizer handles the failure according to the configured [`FailsafeStrategy`].
+/// Invalid output values are handled according to [`FailsafeStrategy`]. Errors returned by the
+/// objective are handled according to the `stop_on_error` configuration.
 pub trait ObjFn: Clone {
     /// Evaluate the objective function at the given points.
     fn eval(&self, x: &ArrayView2<f64>) -> crate::errors::Result<Array2<f64>>;

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -203,12 +203,12 @@ class Egor:
         failsafe_strategy (FailsafeStrategy enum):
             Strategy to handle objective computation failure at a given x point.
             A failure is detected when the objective function returns NaN value(s).
-            Can be either FailsafeStrategy.STOP_ON_FAILURE, FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
+            Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
             Rejection simply ignores the failed point whereas Imputation
             uses the objective surrogate prediction to fill the missing value.
             In the third case Viability, a surrogate is used to model the failure region
             which is used as a constraint and drive the optimization toward the viable region.
-    
+
         seed (int >= 0 or None):
             Deprecated: use seed argument in minimize() or suggest() instead.
     
@@ -228,8 +228,8 @@ class Egor:
     
         Egor object which can be used to optimize a function using the minimize method.
     """
-    def __new__(cls, xspecs: typing.Any, gp_config: GpConfig = ..., n_cstr: builtins.int = 0, cstr_tol: typing.Optional[typing.Sequence[builtins.float]] = None, cstr_specs: typing.Optional[typing.Sequence[CstrSpec]] = None, n_start: builtins.int = 20, n_doe: builtins.int = 0, doe: typing.Optional[numpy.typing.NDArray[numpy.float64]] = None, infill_strategy: InfillStrategy = InfillStrategy.LOG_EI, feasible_infill_strategy: FeasibleInfillStrategy = FeasibleInfillStrategy.NONE, cstr_infill: builtins.bool = False, cstr_strategy: ConstraintStrategy = ConstraintStrategy.MC, qei_config: QEiConfig = ..., infill_optimizer: InfillOptimizer = InfillOptimizer.COBYLA, trego: typing.Optional[typing.Any] = None, coego_n_coop: builtins.int = 0, target: builtins.float = -1.7976931348623157e+308, failsafe_strategy: FailsafeStrategy = FailsafeStrategy.STOP, seed: typing.Optional[builtins.int] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, verbose: typing.Optional[typing.Any] = None) -> Egor: ...
-    def minimize(self, fun: typing.Any, fcstrs: typing.Sequence[typing.Any] = [], fcstr_specs: typing.Sequence[CstrSpec] = [], max_iters: builtins.int = 20, run_info: typing.Optional[typing.Any] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, seed: typing.Optional[builtins.int] = None, timeout: typing.Optional[builtins.float] = None, verbose: typing.Optional[typing.Any] = None) -> EgorOptim:
+    def __new__(cls, xspecs: typing.Any, gp_config: GpConfig = ..., n_cstr: builtins.int = 0, cstr_tol: typing.Optional[typing.Sequence[builtins.float]] = None, cstr_specs: typing.Optional[typing.Sequence[CstrSpec]] = None, n_start: builtins.int = 20, n_doe: builtins.int = 0, doe: typing.Optional[numpy.typing.NDArray[numpy.float64]] = None, infill_strategy: InfillStrategy = InfillStrategy.LOG_EI, feasible_infill_strategy: FeasibleInfillStrategy = FeasibleInfillStrategy.NONE, cstr_infill: builtins.bool = False, cstr_strategy: ConstraintStrategy = ConstraintStrategy.MC, qei_config: QEiConfig = ..., infill_optimizer: InfillOptimizer = InfillOptimizer.COBYLA, trego: typing.Optional[typing.Any] = None, coego_n_coop: builtins.int = 0, target: builtins.float = -1.7976931348623157e+308, failsafe_strategy: FailsafeStrategy = FailsafeStrategy.REJECTION, seed: typing.Optional[builtins.int] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, verbose: typing.Optional[typing.Any] = None) -> Egor: ...
+    def minimize(self, fun: typing.Any, fcstrs: typing.Sequence[typing.Any] = [], fcstr_specs: typing.Sequence[CstrSpec] = [], max_iters: builtins.int = 20, run_info: typing.Optional[typing.Any] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, seed: typing.Optional[builtins.int] = None, timeout: typing.Optional[builtins.float] = None, verbose: typing.Optional[typing.Any] = None, stop_on_error: builtins.bool = False) -> EgorOptim:
         r"""
         This function finds the minimum of a given function "fun"
         
@@ -1246,10 +1246,6 @@ class ExitStatus(enum.Enum):
 class FailsafeStrategy(enum.Enum):
     r"""
     FailsafeStrategy specifies the strategy to use for handling failures during infill optimization.
-    """
-    STOP_ON_FAILURE = ...
-    r"""
-    Stop optimization when the objective function evaluation fails
     """
     REJECTION = ...
     r"""

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -203,12 +203,12 @@ class Egor:
         failsafe_strategy (FailsafeStrategy enum):
             Strategy to handle objective computation failure at a given x point.
             A failure is detected when the objective function returns NaN value(s).
-            Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
+            Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY.
             Rejection simply ignores the failed point whereas Imputation
             uses the objective surrogate prediction to fill the missing value.
             In the third case Viability, a surrogate is used to model the failure region
             which is used as a constraint and drive the optimization toward the viable region.
-
+    
         seed (int >= 0 or None):
             Deprecated: use seed argument in minimize() or suggest() instead.
     
@@ -294,6 +294,10 @@ class Egor:
                 Optional timeout in seconds. The optimization is stopped when the elapsed time
                 exceeds this duration. The actual runtime may slightly exceed the specified timeout
                 as the check is performed after each iteration.
+        
+            stop_on_error (bool):
+                If true, terminate optimization when the objective function returns an error.
+                Otherwise, the error is handled according to failsafe_strategy.
         
             verbose (int, Verbose enum, or None):
                 Logging verbosity level for the optimizer.

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -1245,6 +1245,10 @@ class ExitStatus(enum.Enum):
     r"""
     Solver unexpected exit. See logs for details.
     """
+    OBJECTIVE_FUNCTION_ERROR = ...
+    r"""
+    Objective function returned an error. See logs for details.
+    """
 
 @typing.final
 class FailsafeStrategy(enum.Enum):

--- a/python/egobox/egobox.pyi
+++ b/python/egobox/egobox.pyi
@@ -203,7 +203,7 @@ class Egor:
         failsafe_strategy (FailsafeStrategy enum):
             Strategy to handle objective computation failure at a given x point.
             A failure is detected when the objective function returns NaN value(s).
-            Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
+            Can be either FailsafeStrategy.STOP_ON_FAILURE, FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
             Rejection simply ignores the failed point whereas Imputation
             uses the objective surrogate prediction to fill the missing value.
             In the third case Viability, a surrogate is used to model the failure region
@@ -228,7 +228,7 @@ class Egor:
     
         Egor object which can be used to optimize a function using the minimize method.
     """
-    def __new__(cls, xspecs: typing.Any, gp_config: GpConfig = ..., n_cstr: builtins.int = 0, cstr_tol: typing.Optional[typing.Sequence[builtins.float]] = None, cstr_specs: typing.Optional[typing.Sequence[CstrSpec]] = None, n_start: builtins.int = 20, n_doe: builtins.int = 0, doe: typing.Optional[numpy.typing.NDArray[numpy.float64]] = None, infill_strategy: InfillStrategy = InfillStrategy.LOG_EI, feasible_infill_strategy: FeasibleInfillStrategy = FeasibleInfillStrategy.NONE, cstr_infill: builtins.bool = False, cstr_strategy: ConstraintStrategy = ConstraintStrategy.MC, qei_config: QEiConfig = ..., infill_optimizer: InfillOptimizer = InfillOptimizer.COBYLA, trego: typing.Optional[typing.Any] = None, coego_n_coop: builtins.int = 0, target: builtins.float = -1.7976931348623157e+308, failsafe_strategy: FailsafeStrategy = FailsafeStrategy.REJECTION, seed: typing.Optional[builtins.int] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, verbose: typing.Optional[typing.Any] = None) -> Egor: ...
+    def __new__(cls, xspecs: typing.Any, gp_config: GpConfig = ..., n_cstr: builtins.int = 0, cstr_tol: typing.Optional[typing.Sequence[builtins.float]] = None, cstr_specs: typing.Optional[typing.Sequence[CstrSpec]] = None, n_start: builtins.int = 20, n_doe: builtins.int = 0, doe: typing.Optional[numpy.typing.NDArray[numpy.float64]] = None, infill_strategy: InfillStrategy = InfillStrategy.LOG_EI, feasible_infill_strategy: FeasibleInfillStrategy = FeasibleInfillStrategy.NONE, cstr_infill: builtins.bool = False, cstr_strategy: ConstraintStrategy = ConstraintStrategy.MC, qei_config: QEiConfig = ..., infill_optimizer: InfillOptimizer = InfillOptimizer.COBYLA, trego: typing.Optional[typing.Any] = None, coego_n_coop: builtins.int = 0, target: builtins.float = -1.7976931348623157e+308, failsafe_strategy: FailsafeStrategy = FailsafeStrategy.STOP, seed: typing.Optional[builtins.int] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, verbose: typing.Optional[typing.Any] = None) -> Egor: ...
     def minimize(self, fun: typing.Any, fcstrs: typing.Sequence[typing.Any] = [], fcstr_specs: typing.Sequence[CstrSpec] = [], max_iters: builtins.int = 20, run_info: typing.Optional[typing.Any] = None, outdir: typing.Optional[builtins.str] = None, warm_start: builtins.bool = False, hot_start: typing.Optional[typing.Any] = None, seed: typing.Optional[builtins.int] = None, timeout: typing.Optional[builtins.float] = None, verbose: typing.Optional[typing.Any] = None) -> EgorOptim:
         r"""
         This function finds the minimum of a given function "fun"
@@ -1246,6 +1246,10 @@ class ExitStatus(enum.Enum):
 class FailsafeStrategy(enum.Enum):
     r"""
     FailsafeStrategy specifies the strategy to use for handling failures during infill optimization.
+    """
+    STOP_ON_FAILURE = ...
+    r"""
+    Stop optimization when the objective function evaluation fails
     """
     REJECTION = ...
     r"""

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -177,7 +177,7 @@ fn parse_run_info(py: Python, value: Py<PyAny>) -> PyResult<RunInfo> {
 ///     failsafe_strategy (FailsafeStrategy enum):
 ///         Strategy to handle objective computation failure at a given x point.
 ///         A failure is detected when the objective function returns NaN value(s).
-///         Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY
+///         Can be either FailsafeStrategy.REJECTION, FailsafeStrategy.IMPUTATION, or FailsafeStrategy.VIABILITY.
 ///         Rejection simply ignores the failed point whereas Imputation
 ///         uses the objective surrogate prediction to fill the missing value.
 ///         In the third case Viability, a surrogate is used to model the failure region
@@ -252,7 +252,7 @@ impl Egor {
         trego = None,
         coego_n_coop = 0,
         target = f64::MIN,
-        failsafe_strategy = FailsafeStrategy::StopOnFailure,
+        failsafe_strategy = FailsafeStrategy::Rejection,
         seed = None,
         outdir = None,
         warm_start = false,
@@ -441,6 +441,10 @@ impl Egor {
     ///         exceeds this duration. The actual runtime may slightly exceed the specified timeout
     ///         as the check is performed after each iteration.
     ///
+    ///     stop_on_error (bool):
+    ///         If true, terminate optimization when the objective function returns an error.
+    ///         Otherwise, the error is handled according to failsafe_strategy.
+    ///
     ///     verbose (int, Verbose enum, or None):
     ///         Logging verbosity level for the optimizer.
     ///         Can be either an integer or a Verbose enum value:
@@ -455,7 +459,7 @@ impl Egor {
     ///         x_opt (array[1, nx]): x value where fun is at its minimum subject to constraints
     ///         y_opt (array[1, nx]): fun(x_opt)
     ///
-    #[pyo3(signature = (fun, fcstrs=vec![], fcstr_specs=vec![], max_iters = 20, run_info = None, outdir = None, warm_start = false, hot_start = None, seed = None, timeout = None, verbose = None))]
+    #[pyo3(signature = (fun, fcstrs=vec![], fcstr_specs=vec![], max_iters = 20, run_info = None, outdir = None, warm_start = false, hot_start = None, seed = None, timeout = None, verbose = None, stop_on_error = false))]
     #[allow(clippy::too_many_arguments)]
     fn minimize(
         &self,
@@ -471,6 +475,7 @@ impl Egor {
         seed: Option<u64>,
         timeout: Option<f64>,
         verbose: Option<Py<PyAny>>,
+        stop_on_error: bool,
     ) -> PyResult<EgorOptim> {
         init_logger(py, verbose);
 
@@ -494,7 +499,7 @@ impl Egor {
                     }
                     Err(e) => {
                         log::error!("Error during objective function evaluation: {:?}", e);
-                        Err(egobox_ego::EgoError::UserFnError(e.to_string()))
+                        Err(egobox_ego::EgoError::ObjectiveFunctionError(e.to_string()))
                     }
                 }
             })
@@ -551,6 +556,7 @@ impl Egor {
                     hot_start,
                     seed,
                     timeout,
+                    stop_on_error,
                 )
             })
             .min_within_mixint_space(&self.xtypes)
@@ -648,6 +654,7 @@ impl Egor {
                     None,
                     seed,
                     None,
+                    false,
                 )
             })
             .min_within_mixint_space(&self.xtypes)
@@ -781,7 +788,6 @@ impl Egor {
 
     fn failsafe_strategy(&self) -> egobox_ego::FailsafeStrategy {
         match self.failsafe_strategy {
-            FailsafeStrategy::StopOnFailure => egobox_ego::FailsafeStrategy::StopOnFailure,
             FailsafeStrategy::Rejection => egobox_ego::FailsafeStrategy::Rejection,
             FailsafeStrategy::Imputation => egobox_ego::FailsafeStrategy::Imputation,
             FailsafeStrategy::Viability => egobox_ego::FailsafeStrategy::Viability,
@@ -834,6 +840,7 @@ impl Egor {
         hot_start: Option<u64>,
         seed: Option<u64>,
         timeout: Option<f64>,
+        stop_on_error: bool,
     ) -> egobox_ego::EgorConfig {
         let infill_strategy = self.infill_strategy();
         let feasible_infill_strategy = self.feasible_infill_strategy();
@@ -891,6 +898,7 @@ impl Egor {
             .infill_optimizer(infill_optimizer)
             .coego(coego_status)
             .target(self.target)
+            .stop_on_error(stop_on_error)
             .warm_start(warm_start)
             .hot_start(hot_start.into())
             .failsafe_strategy(failsafe_strategy);

--- a/python/src/egor.rs
+++ b/python/src/egor.rs
@@ -252,7 +252,7 @@ impl Egor {
         trego = None,
         coego_n_coop = 0,
         target = f64::MIN,
-        failsafe_strategy = FailsafeStrategy::Rejection,
+        failsafe_strategy = FailsafeStrategy::StopOnFailure,
         seed = None,
         outdir = None,
         warm_start = false,
@@ -781,6 +781,7 @@ impl Egor {
 
     fn failsafe_strategy(&self) -> egobox_ego::FailsafeStrategy {
         match self.failsafe_strategy {
+            FailsafeStrategy::StopOnFailure => egobox_ego::FailsafeStrategy::StopOnFailure,
             FailsafeStrategy::Rejection => egobox_ego::FailsafeStrategy::Rejection,
             FailsafeStrategy::Imputation => egobox_ego::FailsafeStrategy::Imputation,
             FailsafeStrategy::Viability => egobox_ego::FailsafeStrategy::Viability,

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -1,3 +1,4 @@
+use egobox_ego::OBJECTIVE_FUNCTION_ERROR;
 use numpy::{PyArray1, PyArray2};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -598,6 +599,8 @@ pub(crate) enum ExitStatus {
     Timeout = 5,
     /// Solver unexpected exit. See logs for details.
     UnexpectedExit = 6,
+    /// Objective function returned an error. See logs for details.
+    ObjectiveFunctionError = 7,
 }
 
 impl From<argmin::core::TerminationStatus> for ExitStatus {
@@ -609,6 +612,7 @@ impl From<argmin::core::TerminationStatus> for ExitStatus {
                 TerminationReason::TargetCostReached => ExitStatus::TargetCostReached,
                 TerminationReason::SolverConverged => ExitStatus::SolverConverged,
                 TerminationReason::Timeout => ExitStatus::Timeout,
+                TerminationReason::SolverExit(val) if val == OBJECTIVE_FUNCTION_ERROR => ExitStatus::ObjectiveFunctionError,
                 TerminationReason::SolverExit(_) => ExitStatus::UnexpectedExit,
                 TerminationReason::Interrupt => ExitStatus::Interrupt,
             },

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -615,7 +615,7 @@ impl From<argmin::core::TerminationStatus> for ExitStatus {
                 TerminationReason::SolverExit(val) if val == OBJECTIVE_FUNCTION_ERROR => {
                     ExitStatus::ObjectiveFunctionError
                 }
-                TerminationReason::SolverExit(_) => ExitStatus::UnexpectedExit,
+                TerminationReason::SolverExit(_) => unreachable!("Unexpected solver exit reason"),
                 TerminationReason::Interrupt => ExitStatus::Interrupt,
             },
             TerminationStatus::NotTerminated => ExitStatus::UnexpectedExit,

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -612,7 +612,9 @@ impl From<argmin::core::TerminationStatus> for ExitStatus {
                 TerminationReason::TargetCostReached => ExitStatus::TargetCostReached,
                 TerminationReason::SolverConverged => ExitStatus::SolverConverged,
                 TerminationReason::Timeout => ExitStatus::Timeout,
-                TerminationReason::SolverExit(val) if val == OBJECTIVE_FUNCTION_ERROR => ExitStatus::ObjectiveFunctionError,
+                TerminationReason::SolverExit(val) if val == OBJECTIVE_FUNCTION_ERROR => {
+                    ExitStatus::ObjectiveFunctionError
+                }
                 TerminationReason::SolverExit(_) => ExitStatus::UnexpectedExit,
                 TerminationReason::Interrupt => ExitStatus::Interrupt,
             },

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -246,6 +246,8 @@ pub(crate) enum FeasibleInfillStrategy {
 #[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub(crate) enum FailsafeStrategy {
+    /// Stop optimization when the objective function evaluation fails
+    StopOnFailure = 4,
     /// The point is ignored, the optimization continues but may fail to explore
     /// another region of the search space
     Rejection = 1,
@@ -268,11 +270,12 @@ impl<'a, 'py> FromPyObject<'a, 'py> for FailsafeStrategy {
             Ok(1) => Ok(Self::Rejection),
             Ok(2) => Ok(Self::Imputation),
             Ok(3) => Ok(Self::Viability),
+            Ok(4) => Ok(Self::StopOnFailure),
             Ok(v) => Err(PyValueError::new_err(format!(
-                "failsafe_strategy integer value must be in [1, 3], got {v}"
+                "failsafe_strategy integer value must be in [1, 4], got {v}"
             ))),
             Err(_) => Err(PyTypeError::new_err(
-                "failsafe_strategy must be a FailsafeStrategy enum or an integer in [1, 3]",
+                "failsafe_strategy must be a FailsafeStrategy enum or an integer in [1, 4]",
             )),
         }
     }

--- a/python/src/types.rs
+++ b/python/src/types.rs
@@ -246,8 +246,6 @@ pub(crate) enum FeasibleInfillStrategy {
 #[pyclass(skip_from_py_object, eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub(crate) enum FailsafeStrategy {
-    /// Stop optimization when the objective function evaluation fails
-    StopOnFailure = 4,
     /// The point is ignored, the optimization continues but may fail to explore
     /// another region of the search space
     Rejection = 1,
@@ -270,12 +268,11 @@ impl<'a, 'py> FromPyObject<'a, 'py> for FailsafeStrategy {
             Ok(1) => Ok(Self::Rejection),
             Ok(2) => Ok(Self::Imputation),
             Ok(3) => Ok(Self::Viability),
-            Ok(4) => Ok(Self::StopOnFailure),
             Ok(v) => Err(PyValueError::new_err(format!(
-                "failsafe_strategy integer value must be in [1, 4], got {v}"
+                "failsafe_strategy integer value must be in [1, 3], got {v}"
             ))),
             Err(_) => Err(PyTypeError::new_err(
-                "failsafe_strategy must be a FailsafeStrategy enum or an integer in [1, 4]",
+                "failsafe_strategy must be a FailsafeStrategy enum or an integer in [1, 3]",
             )),
         }
     }

--- a/python/tests/test_egor.py
+++ b/python/tests/test_egor.py
@@ -615,6 +615,22 @@ class TestEgor(unittest.TestCase):
         self.assertAlmostEqual(0.9677, optim.result.x_opt[0], delta=5e-2)
         self.assertAlmostEqual(0.2067, optim.result.x_opt[1], delta=6e-2)
 
+    def test_stop_on_error(self):
+        calls = 0
+        EXPECTED_CALLS_BEFORE_ERROR = 3
+
+        def fobj_error(x):
+            nonlocal calls
+            calls += 1
+            if calls > EXPECTED_CALLS_BEFORE_ERROR:
+                raise RuntimeError("simulated objective error")
+            return np.zeros((np.atleast_2d(x).shape[0], 1))
+
+        egor = egx.Egor([[0.0, 1.0]])
+        optim = egor.minimize(fobj_error, max_iters=10, seed=42, stop_on_error=True)
+
+        self.assertEqual(optim.status.exit, egx.ExitStatus.OBJECTIVE_FUNCTION_ERROR)
+        self.assertEqual(optim.status.total_iters, EXPECTED_CALLS_BEFORE_ERROR)
 
 if __name__ == "__main__":
     unittest.main(defaultTest=["TestEgor.test_fobj_crash"], exit=False)

--- a/python/tests/test_egor.py
+++ b/python/tests/test_egor.py
@@ -632,5 +632,6 @@ class TestEgor(unittest.TestCase):
         self.assertEqual(optim.status.exit, egx.ExitStatus.OBJECTIVE_FUNCTION_ERROR)
         self.assertEqual(optim.status.total_iters, EXPECTED_CALLS_BEFORE_ERROR)
 
+
 if __name__ == "__main__":
     unittest.main(defaultTest=["TestEgor.test_fobj_crash"], exit=False)


### PR DESCRIPTION
So far, Egor handles objective function error as if the objective function returned NaN values which are in turn managed regarding the failsafe strategy configuration.

With this PR, a dedicated `stop_on_error` parameter of `Egor.minimize()` allows to handle objective function error as described below:
* When `minimize(stop_on_error=True, ...)` if the objective function exits on error (raises exception or crash) the optimizer terminates with the new exit status = `OBJECTIVE_FUNCTION_ERROR`
* When `minimize(stop_on_error=False, ...)` the optimizer handles objective error as before with `NaN`s
* In any case `NaN` values are handled by `failsafe_strategy` configuration as before
* `stop_on_error=False` is the default to keep the same behaviour as before

