### PR TITLE
Fix warm_start with non canonical constraint

### DIFF
--- a/crates/ego/src/egor.rs
+++ b/crates/ego/src/egor.rs
@@ -1155,6 +1155,47 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_egor_warm_start_metamodelized_geq_constraints() {
+        let outdir = "target/test_warmstart_geq_constraints";
+        let _ = std::fs::remove_dir_all(outdir);
+        let xlimits = array![[0., 3.], [0., 4.]];
+
+        let first = EgorBuilder::optimize(f_g24_geq)
+            .configure(|config| {
+                config
+                    .cstr_specs(vec![CstrSpec::Geq(0.0), CstrSpec::Geq(0.0)])
+                    .n_doe(15)
+                    .max_iters(1)
+                    .outdir(outdir)
+                    .seed(42)
+            })
+            .min_within(&xlimits)
+            .expect("Egor configured")
+            .run()
+            .expect("Initial minimization");
+
+        let restarted = EgorBuilder::optimize(f_g24_geq)
+            .configure(|config| {
+                config
+                    .cstr_specs(vec![CstrSpec::Geq(0.0), CstrSpec::Geq(0.0)])
+                    .n_doe(15)
+                    .max_iters(0)
+                    .outdir(outdir)
+                    .warm_start(true)
+                    .seed(42)
+            })
+            .min_within(&xlimits)
+            .expect("Egor configured")
+            .run()
+            .expect("Warm-start minimization");
+
+        assert_abs_diff_eq!(first.x_opt, restarted.x_opt, epsilon = 1e-12);
+        assert_abs_diff_eq!(first.y_opt, restarted.y_opt, epsilon = 1e-12);
+        let _ = std::fs::remove_dir_all(outdir);
+    }
+
+    #[test]
+    #[serial]
     #[ignore = "fail on CI on windows-2025, work on windows locally"]
     fn test_egor_g24_basic_egor_builder_slsqp() {
         let xlimits = array![[0., 3.], [0., 4.]];

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -238,7 +238,9 @@ where
         };
         // Warm-start DOE constraint columns are already in canonical form.
         // otherwise transform constraints to canonical form (ie. cstr < 0)
-        let y_data = if !warm_start_doe.is_some() && let Some(ref specs) = self.config.cstr_specs {
+        let y_data = if !warm_start_doe.is_some()
+            && let Some(ref specs) = self.config.cstr_specs
+        {
             crate::types::transform_constraints(&y_data, specs)
         } else {
             y_data

--- a/crates/ego/src/solver/egor_solver.rs
+++ b/crates/ego/src/solver/egor_solver.rs
@@ -192,7 +192,7 @@ where
             Xoshiro256Plus::from_entropy()
         };
 
-        let hstart_doe: Option<Array2<f64>> = if self.config.warm_start
+        let warm_start_doe: Option<Array2<f64>> = if self.config.warm_start
             && let Some(path) = self.config.outdir.as_ref()
         {
             let filepath = std::path::Path::new(&path).join(DOE_FILE);
@@ -210,7 +210,7 @@ where
             None
         };
 
-        let doe = hstart_doe.as_ref().or(self.config.doe.as_ref());
+        let doe = warm_start_doe.as_ref().or(self.config.doe.as_ref());
 
         let (y_data, x_data) = if let Some(doe) = doe {
             if doe.ncols() == self.xlimits.nrows() {
@@ -236,8 +236,9 @@ where
             let x = sampling.sample(n_doe);
             (self.eval_obj(problem, &x)?, x)
         };
-        // Apply constraint transformation if cstr_specs are set
-        let y_data = if let Some(ref specs) = self.config.cstr_specs {
+        // Warm-start DOE constraint columns are already in canonical form.
+        // otherwise transform constraints to canonical form (ie. cstr < 0)
+        let y_data = if !warm_start_doe.is_some() && let Some(ref specs) = self.config.cstr_specs {
             crate::types::transform_constraints(&y_data, specs)
         } else {
             y_data

--- a/python/tests/test_egor.py
+++ b/python/tests/test_egor.py
@@ -282,9 +282,10 @@ class TestEgor(unittest.TestCase):
         x_expected = optim.result.x_opt
         y_expected = optim.result.y_opt
 
-        # When warm starting with no iteration, the result should be 
-        # the same as the previous run
-        optim = egor.minimize(g24_geq, max_iters=0, seed=42, outdir="./test_dir", warm_start=True)
+        # When warm starting with no iteration, the result should be the same as the previous run
+        optim = egor.minimize(
+            g24_geq, max_iters=0, seed=42, outdir="./test_dir", warm_start=True
+        )
         np.testing.assert_allclose(optim.result.x_opt, x_expected)
         np.testing.assert_allclose(optim.result.y_opt, y_expected)
 

--- a/python/tests/test_egor.py
+++ b/python/tests/test_egor.py
@@ -90,6 +90,11 @@ def g24(point):
     return res
 
 
+def g24_geq(point):
+    p = np.atleast_2d(point)
+    return np.array([G24(p), -G24_c1(p), -G24_c2(p)]).T
+
+
 def g24_bare(point):
     p = np.atleast_2d(point)
     res = np.array([G24(p)]).T
@@ -262,6 +267,32 @@ class TestEgor(unittest.TestCase):
         self.assertAlmostEqual(3.1785, optim.result.x_opt[1], delta=1e-2)
         self.assertGreaterEqual(n_doe + max_iters, optim.result.x_doe.shape[0])
         self.assertEqual(1 + n_cstr, optim.result.y_doe.shape[1])
+
+    def test_reinit(self):
+        n_doe = 15
+        egor = egx.Egor(
+            [[0.0, 3.0], [0.0, 4.0]],
+            cstr_specs=[egx.CstrSpec.geq(0.0), egx.CstrSpec.geq(0.0)],
+            cstr_tol=np.array([1e-3, 1e-3]),
+            n_doe=n_doe,
+            cstr_strategy=egx.ConstraintStrategy.UTB,
+        )
+        optim = egor.minimize(g24_geq, max_iters=1, seed=42, outdir="./test_dir")
+
+        x_expected = optim.result.x_opt
+        y_expected = optim.result.y_opt
+
+        # When warm starting with no iteration, the result should be 
+        # the same as the previous run
+        optim = egor.minimize(g24_geq, max_iters=0, seed=42, outdir="./test_dir", warm_start=True)
+        np.testing.assert_allclose(optim.result.x_opt, x_expected)
+        np.testing.assert_allclose(optim.result.y_opt, y_expected)
+
+        # delete test_dir
+        if os.path.exists("./test_dir"):
+            import shutil
+
+            shutil.rmtree("./test_dir")
 
     def test_g24_kpls(self):
         egor = egx.Egor(


### PR DESCRIPTION
This PR fixes warm_start feature in presence of non canonical constraint (eg non c <= 0).

Canonical constraint values loaded from a saved DOE are no longer transformed a second time.